### PR TITLE
Add Pi SDK integration to both design docs

### DIFF
--- a/docs/COGNITIVE-RESOURCE-MANAGEMENT.md
+++ b/docs/COGNITIVE-RESOURCE-MANAGEMENT.md
@@ -188,32 +188,57 @@ optionally by a tier-1 model for borderline cases.
 
 ---
 
-## 6. Local Model Integration
+## 6. Local Model Integration via Pi
 
-### 6.1 Runtime Adapter
+### 6.1 pi-ai Instead of a New Adapter
 
-Add an `ollama` runtime adapter to HIVE's existing adapter registry. Ollama
-exposes an OpenAI-compatible API, so the adapter is thin:
+The Phase 1 design doc establishes that the persistent steward uses Pi's
+`Agent` class from `@mariozechner/pi-agent-core`. Pi's underlying LLM
+library, `@mariozechner/pi-ai`, already supports Ollama as a provider via
+its OpenAI-compatible API support:
 
-- `command`: `ollama`
-- `detectInstalled`: check for `ollama` binary
-- model selection via the existing `model:` field in agent descriptors
-- output parsing via the OpenAI-compatible JSON response format
+```typescript
+import { getModel, complete } from "@mariozechner/pi-ai";
 
-This gives HIVE local model support through the same interface it already uses
-for Claude, Codex, and Gemini.
+// Local model via Ollama
+const local = getModel("ollama", "qwen3.5:4b");
+
+// Cloud model via Anthropic
+const cloud = getModel("anthropic", "claude-haiku-4-5-20251001");
+```
+
+This means tier-1 tasks use the same `complete()` / `stream()` API
+regardless of whether they hit a local model or a cloud model. No separate
+"ollama adapter" in HIVE's runtime registry is needed for tier-1 work —
+pi-ai handles the provider abstraction.
+
+HIVE's existing runtime adapter system (`src/lib/runtime.ts`) remains for
+launching disposable worker processes (tier-2). An Ollama adapter there is
+still useful for workers that run locally, but it's a separate concern from
+tier-1 routing.
 
 ### 6.2 Discovery
 
 On gateway startup, probe for available local models:
 
-```
-ollama list → available models and their sizes
+```typescript
+import { getModel } from "@mariozechner/pi-ai";
+
+// Check if Ollama is available and which models are loaded
+async function discoverLocalModels(): Promise<string[]> {
+  try {
+    const response = await fetch("http://localhost:11434/api/tags");
+    const data = await response.json();
+    return data.models.map((m: any) => m.name);
+  } catch {
+    return []; // Ollama not running
+  }
+}
 ```
 
-Store the result in derived state. The routing policy uses this to know what's
-locally available. If Ollama isn't running or has no models, tier-1 falls back
-to Haiku seamlessly.
+Store the result in derived state. The routing policy uses this to know
+what's locally available. If Ollama isn't running or has no models, tier-1
+falls back to Haiku seamlessly.
 
 ### 6.3 Model Selection Heuristics
 
@@ -223,12 +248,23 @@ For tier-1 tasks, prefer:
 2. Haiku if no local model or task benefits from stronger instruction following
 3. Both in parallel if the task is ambiguous and we want agreement
 
-Keep this simple. A config file maps task types to preferred models:
+Keep this simple. A config file maps tiers to preferred models:
 
 ```
 tier1_local: qwen3.5:4b
 tier1_cloud: haiku
 tier1_fallback: haiku
+```
+
+In code, this becomes:
+
+```typescript
+function getTier1Model(config: TierConfig): Model {
+  if (config.tier1_local && localModels.includes(config.tier1_local)) {
+    return getModel("ollama", config.tier1_local);
+  }
+  return getModel("anthropic", "claude-haiku-4-5-20251001");
+}
 ```
 
 Don't build a dynamic model marketplace. A static config that the user can
@@ -303,8 +339,10 @@ over time instead of growing unboundedly.
 
 ## 8. Usage Tracking
 
-HIVE already captures per-run token metadata in `RuntimeMetadata`. Phase 2
-extends this with aggregated tracking.
+HIVE already captures per-run token metadata in `RuntimeMetadata` for
+worker processes. Pi's `message.usage` provides the same data (input tokens,
+output tokens, cost) for steward and tier-1 calls. Phase 2 unifies these
+into aggregated tracking.
 
 ### 8.1 What to Track
 
@@ -484,25 +522,61 @@ UI components, just new data in existing containers.
 
 ## 10. Implementation Plan
 
-### Step 1: Ollama Adapter
+### Step 1: Add pi-ai and pi-agent-core Dependencies
 
-Add an `ollama` runtime adapter to the existing adapter registry. Test with
-Qwen 3.5 4B and Gemma 3 4B. Verify output parsing and model selection work
-through the standard HIVE flow.
+Add `@mariozechner/pi-ai` and `@mariozechner/pi-agent-core` to the project.
+Verify basic operation:
+
+```typescript
+import { getModel, complete } from "@mariozechner/pi-ai";
+
+// Test cloud
+const haiku = getModel("anthropic", "claude-haiku-4-5-20251001");
+const response = await complete(haiku, {
+  messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+});
+
+// Test local (if Ollama running)
+const local = getModel("ollama", "qwen3.5:4b");
+const localResponse = await complete(local, {
+  messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+});
+```
+
+This also validates Ollama connectivity. If Ollama isn't available, tier-1
+falls back to Haiku — test that path too.
 
 ### Step 2: Tier-1 Task Runner
 
 Add a lightweight function that routes a tier-1 task (prompt + context) to
-either a local model or Haiku based on availability. This is not a new
-daemon — it's a function the gateway and supervisor can call.
+either a local model or Haiku based on availability. Uses `complete()` from
+pi-ai directly — no Agent needed for stateless tasks.
 
 ```typescript
+import { getModel, complete } from "@mariozechner/pi-ai";
+
 async function runTier1Task(task: {
   prompt: string;
   context: string;
   preferLocal: boolean;
-}): Promise<{ result: string; model: string; tokens: number }>
+}): Promise<{ result: string; model: string; tokens: number }> {
+  const model = task.preferLocal && localModels.length > 0
+    ? getModel("ollama", config.tier1_local)
+    : getModel("anthropic", "claude-haiku-4-5-20251001");
+
+  const response = await complete(model, {
+    systemPrompt: task.prompt,
+    messages: [{ role: "user", content: task.context, timestamp: Date.now() }],
+  });
+
+  const text = response.content.find(b => b.type === "text")?.text ?? "";
+  const tokens = (response.usage?.input ?? 0) + (response.usage?.output ?? 0);
+
+  return { result: text, model: model.name, tokens };
+}
 ```
+
+This is not a daemon — it's a function the gateway and supervisor can call.
 
 ### Step 3: Worker Output Compression
 
@@ -512,9 +586,13 @@ the run record. Feed the digest (not the full output) to the steward.
 
 ### Step 4: Usage Tracking
 
-Aggregate `RuntimeMetadata` from completed runs into `usage.json`. Add a
-`GET /api/cognition` gateway endpoint that returns per-tier token counts,
-model availability, and budget status.
+Unify token tracking from two sources:
+
+- `RuntimeMetadata` from worker process runs (existing)
+- `message.usage` from pi-ai calls (steward + tier-1)
+
+Aggregate into `usage.json`. Add a `GET /api/cognition` gateway endpoint
+that returns per-tier token counts, model availability, and budget status.
 
 ### Step 5: Console UI
 
@@ -524,6 +602,8 @@ Add the three UI layers:
    `run-completed` and `supervisor-tick` WebSocket events.
 2. Turn model chips — extend the existing detail chip rendering in `app.js`
    to include model name and token count from the response metadata.
+   The steward's `agent.subscribe()` events include model info; pass it
+   through the WebSocket `console-response` payload.
 3. Feed cognition section — collapsible panel reading from `/api/cognition`,
    showing tier bars and model status. Collapsed by default.
 

--- a/docs/PERSISTENT-STEWARD-DESIGN.md
+++ b/docs/PERSISTENT-STEWARD-DESIGN.md
@@ -126,15 +126,56 @@ A mixed pool of workers, unchanged from today:
 
 Pi is the session engine for the persistent steward.
 
-Pi provides:
+### 4.1 The Packages
 
-- session continuity across turns without prompt rebuild
-- hot conversational context with automatic compaction
-- tool and capability invocation
-- model and provider routing
-- a stable identity-bearing runtime object
+Two Pi packages matter for HIVE:
 
-Pi does not become:
+**`@mariozechner/pi-ai`** — unified multi-provider LLM API. Provides
+`getModel()`, `stream()`, `complete()`, and a serializable `Context` object.
+Handles token/cost tracking, tool schemas (TypeBox), and works across 20+
+providers including Ollama for local models. This is what HIVE uses for all
+model calls — steward, tier-1, and potentially workers.
+
+**`@mariozechner/pi-agent-core`** — agent runtime with tool calling and state
+management. Provides the `Agent` class: persistent message history, streaming
+events, tool execution, context transformation, steering/follow-up queues,
+and abort control. This is what HIVE uses for the persistent steward session.
+
+### 4.2 What Pi Provides
+
+**Session continuity.** The `Agent` class maintains message history across
+turns. No prompt rebuild. The steward's context grows incrementally with each
+human message and delta packet, exactly matching our context contract.
+
+**Context transformation.** `transformContext()` runs before every LLM call.
+This is where HIVE injects delta packets, prunes stale context, and enforces
+the bootstrap/refresh contract. The agent's full message history stays in
+memory, but the LLM only sees what the transform passes through.
+
+**Streaming.** `agent.subscribe()` emits granular events (`text_delta`,
+`tool_execution_start`, `tool_execution_end`, etc.) that map directly to
+WebSocket broadcasts in the gateway console. The human sees the steward
+thinking in real time.
+
+**Tool calling.** The steward's tools (read board, assign worker, check
+status, read file, update plan) are registered as `AgentTool` objects with
+TypeBox schemas. Pi handles argument validation, parallel/sequential
+execution, and result injection.
+
+**Steering.** If the human sends a message while the steward is mid-tool-call,
+`agent.steer()` interrupts cleanly — remaining tools get skipped, the
+steering message injects, and the steward responds to the interruption. This
+is critical for the conversational feel.
+
+**Model swapping.** `agent.setModel()` can change the underlying model
+mid-session. If budget pressure requires downgrading the steward temporarily,
+or if a specific turn benefits from a different model, this is a single call.
+
+**Provider routing.** `getModel()` works across Anthropic, OpenAI, Google,
+Ollama, and 15+ other providers. HIVE's tier-1 calls use the same API
+regardless of whether they hit a local Qwen model or cloud Haiku.
+
+### 4.3 What Pi Does Not Become
 
 - the durable memory system (HIVE files)
 - the project state system (HIVE substrate)
@@ -147,6 +188,227 @@ everything else.**
 This preserves HIVE's runtime-agnostic stance. Workers still launch via any
 adapter. Only the steward uses Pi, because only the steward needs persistent
 sessions and fast interactive response.
+
+### 4.4 Concrete Mapping
+
+```
+HIVE Concept                  Pi Implementation
+─────────────────────────────────────────────────────
+Persistent steward session    Agent instance in gateway
+Bootstrap context             initialState.systemPrompt + messages
+Delta packets                 Custom AgentMessage via declaration merging
+Context contract              transformContext() callback
+Steward tools                 AgentTool[] with TypeBox schemas
+Live console streaming        agent.subscribe() → WebSocket broadcast
+Human interrupts steward      agent.steer()
+Human follow-up               agent.followUp()
+Steward crash recovery        Re-create Agent from derived state + history
+Tier-1 task calls             complete() / stream() from pi-ai directly
+Model tiering                 getModel('anthropic', 'haiku') vs
+                              getModel('ollama', 'qwen3.5:4b') vs
+                              getModel('anthropic', 'opus')
+Token/cost tracking           message.usage.{input,output,cost}
+```
+
+### 4.5 The Steward Agent Skeleton
+
+```typescript
+import { Agent, AgentTool } from "@mariozechner/pi-agent-core";
+import { getModel, Type } from "@mariozechner/pi-ai";
+
+// Extend AgentMessage for HIVE-specific message types
+declare module "@mariozechner/pi-agent-core" {
+  interface CustomAgentMessages {
+    hiveDelta: {
+      role: "hiveDelta";
+      delta: HiveDeltaPacket;
+      timestamp: number;
+    };
+  }
+}
+
+// --- Tools the steward can call ---
+
+const readBoardTool: AgentTool<typeof readBoardSchema> = {
+  name: "read_board",
+  description: "Read the current BOARD.md state",
+  parameters: Type.Object({}),
+  execute: async () => {
+    const board = await readFile(paths.board());
+    return { result: board };
+  },
+};
+
+const assignWorkerTool: AgentTool<typeof assignWorkerSchema> = {
+  name: "assign_worker",
+  description: "Create an assignment message for a worker agent",
+  parameters: Type.Object({
+    agent: Type.String({ description: "Target agent (architect, craftsman, critic, scout)" }),
+    task: Type.String({ description: "The assignment body" }),
+    priority: Type.Optional(Type.String({ description: "high, normal, low" })),
+  }),
+  execute: async ({ agent, task, priority }) => {
+    await createAssignmentMessage(agent, task, priority);
+    return { result: `Assignment created for ${agent}` };
+  },
+};
+
+const readFileTool: AgentTool<typeof readFileSchema> = {
+  name: "read_file",
+  description: "Read a specific hive file when deeper context is needed",
+  parameters: Type.Object({
+    path: Type.String({ description: "Path relative to ~/.hive/" }),
+  }),
+  execute: async ({ path }) => {
+    const content = await readFile(resolve(paths.hiveHome(), path));
+    return { result: content };
+  },
+};
+
+// --- The steward agent ---
+
+function createStewardAgent(bootstrap: BootstrapContext): Agent {
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: buildStewardSystemPrompt(bootstrap),
+      model: getModel("anthropic", "claude-opus-4-20250514"),
+      tools: [readBoardTool, assignWorkerTool, readFileTool, checkStatusTool, updatePlanTool],
+      messages: bootstrap.conversationTail ?? [],
+    },
+
+    // The context contract: prune and inject deltas before each LLM call
+    transformContext: async (messages, signal) => {
+      const delta = await getLatestDelta();
+      const llmMessages = messages
+        .filter(m => m.role !== "hiveDelta")  // strip raw deltas
+        .slice(-MAX_CONTEXT_MESSAGES);        // keep recent window
+
+      // Inject current delta as a system-like user message
+      if (delta.hasChanges) {
+        llmMessages.push({
+          role: "user",
+          content: formatDeltaForSteward(delta),
+          timestamp: Date.now(),
+        });
+      }
+
+      return llmMessages;
+    },
+  });
+
+  return agent;
+}
+```
+
+### 4.6 Gateway Integration
+
+```typescript
+// In gateway startup
+let steward: Agent | null = null;
+
+async function ensureSteward(): Promise<Agent> {
+  if (steward) return steward;
+
+  const bootstrap = await buildBootstrapContext(activeProject);
+  steward = createStewardAgent(bootstrap);
+
+  // Wire streaming to WebSocket
+  steward.subscribe((event) => {
+    if (event.type === "message_update") {
+      broadcast({
+        type: "console-response",
+        data: {
+          delta: event.assistantMessageEvent,
+          model: steward!.state.model.name,
+        },
+      });
+    }
+    if (event.type === "tool_execution_start") {
+      broadcast({
+        type: "steward-tool",
+        data: { tool: event.toolName, status: "started" },
+      });
+    }
+  });
+
+  return steward;
+}
+
+// Replace runDirectStewardTurn in POST /api/console/send
+async function handleConsoleSend(message: string) {
+  try {
+    const agent = await ensureSteward();
+
+    // Record the delta for this turn
+    await recordDeltaCheckpoint();
+
+    // Prompt the steward (streams via subscribe above)
+    await agent.prompt(message);
+
+    // Extract usage for tracking
+    const lastMsg = agent.state.messages.at(-1);
+    if (lastMsg?.usage) {
+      await recordUsage("tier3", lastMsg.usage);
+    }
+  } catch (err) {
+    // Steward died — fall back to one-shot
+    steward = null;
+    return runDirectStewardTurn(message);
+  }
+}
+
+// Human sends while steward is working
+async function handleSteeringMessage(message: string) {
+  const agent = await ensureSteward();
+  agent.steer({
+    role: "user",
+    content: message,
+    timestamp: Date.now(),
+  });
+}
+```
+
+### 4.7 Tier-1 via pi-ai Directly
+
+Tier-1 tasks don't need the full Agent. They use `complete()` from pi-ai:
+
+```typescript
+import { getModel, complete } from "@mariozechner/pi-ai";
+
+async function runTier1Task(task: {
+  prompt: string;
+  context: string;
+  preferLocal: boolean;
+}): Promise<{ result: string; model: string; tokens: number }> {
+  // Pick model based on availability
+  const model = task.preferLocal && ollamaAvailable
+    ? getModel("ollama", config.tier1_local)     // e.g. qwen3.5:4b
+    : getModel("anthropic", "claude-haiku-4-5-20251001");
+
+  const response = await complete(model, {
+    systemPrompt: "You are a concise summarization assistant. Respond with JSON only.",
+    messages: [
+      { role: "user", content: `${task.prompt}\n\n${task.context}`, timestamp: Date.now() },
+    ],
+  });
+
+  return {
+    result: response.content.find(b => b.type === "text")?.text ?? "",
+    model: model.name,
+    tokens: (response.usage?.input ?? 0) + (response.usage?.output ?? 0),
+  };
+}
+
+// Example: compress worker output after run completion
+async function compressWorkerOutput(runRecord: RunRecord): Promise<string> {
+  const { result } = await runTier1Task({
+    prompt: `Summarize this worker output as JSON: { "summary": "...", "outcome": "success|partial|blocked|failed", "key_decisions": [...], "files_changed": [...] }`,
+    context: runRecord.visibleOutput,
+    preferLocal: true,
+  });
+  return result;
+}
+```
 
 ---
 


### PR DESCRIPTION
Summary
Phase 1 design: persistent Pi-backed steward session in the gateway, replacing one-shot runDirectStewardTurn() with a live Agent instance
Phase 2 design: cognitive resource management with tiered routing (deterministic → local Qwen/Gemma → Haiku → Sonnet workers → Opus steward)
Concrete Pi SDK integration: pi-agent-core for the steward, pi-ai for all model calls including local Ollama
Console UI design: topbar budget chip, per-turn model chips, collapsible cognition panel