### PR TITLE
Add verification workflow for completed worker assignments

### DIFF
--- a/src/commands/supervise.ts
+++ b/src/commands/supervise.ts
@@ -14,12 +14,21 @@ import { appendFeedEntry } from "../lib/feed";
 import { UsageError } from "../lib/errors";
 import { section } from "../lib/format";
 import { appendLogEntry } from "../lib/log";
-import { findMessage, listOpenProjectMessages } from "../lib/messages";
+import {
+  findMessage,
+  closeMessage,
+  listOpenProjectMessages,
+  HiveMessage,
+  createMessageRaw,
+} from "../lib/messages";
 import {
   ensureHiveScaffold,
   getActiveProject,
   getProjectPaths,
+  HivePaths,
+  ProjectPaths,
 } from "../lib/paths";
+import { extractRepoPath } from "../lib/project";
 import {
   finalizeRun,
   listActiveRuns,
@@ -33,11 +42,15 @@ import {
 import {
   assessRecoveredRuns,
   assessStewardLaunch,
+  countPriorAttempts,
   DEFAULT_MAX_PARALLEL,
   DEFAULT_STEWARD_REASSESS_SECONDS,
   DEFAULT_SUPERVISOR_INTERVAL_SECONDS,
+  extractVerificationSpec,
   RecoveredRun,
+  runVerification,
   selectWorkerLaunches,
+  VerificationOutcome,
 } from "../lib/supervisor";
 import { toIsoTimestamp } from "../lib/time";
 import { refreshProjectRuntimeState } from "../lib/state";
@@ -235,6 +248,149 @@ async function reconcileRecoveredRuns(input: {
   }
 }
 
+async function verifyCompletedWorker(input: {
+  paths: HivePaths;
+  projectPaths: ProjectPaths;
+  activeProject: string;
+  agentId: string;
+  sourceMessage: HiveMessage;
+  allRuns: RunRecord[];
+}): Promise<{ outcome: VerificationOutcome; summary: string } | null> {
+  const spec = extractVerificationSpec(input.sourceMessage);
+
+  if (!spec) {
+    return null;
+  }
+
+  const projectConfig = await Bun.file(input.projectPaths.config).text();
+  const repoPath = extractRepoPath(projectConfig);
+
+  if (!repoPath) {
+    return null;
+  }
+
+  const attempt = countPriorAttempts(input.sourceMessage.filename, input.allRuns);
+  const outcome = runVerification({ spec, repoPath, attempt });
+
+  if (outcome.action === "keep") {
+    const summary = `verify PASS: ${spec.command} (attempt ${attempt}/${spec.maxAttempts})`;
+
+    await appendLogEntry(
+      input.projectPaths.log,
+      "hive supervise verify",
+      `${input.agentId}: ${summary}`,
+    );
+    await appendFeedEntry(input.paths, {
+      project: input.activeProject,
+      headline: `${input.agentId} verified`,
+      details: [
+        `command: ${spec.command}`,
+        `result: PASS`,
+        `attempt: ${attempt}/${spec.maxAttempts}`,
+      ],
+    });
+
+    return { outcome, summary };
+  }
+
+  if (outcome.action === "retry") {
+    const summary = `verify FAIL: ${spec.command} (attempt ${outcome.attempt}/${outcome.maxAttempts}, will retry)`;
+
+    // Close the old assignment
+    await closeMessage(
+      input.paths.msgDir,
+      input.sourceMessage.filename,
+      "supervisor",
+      `Verification failed (attempt ${outcome.attempt}/${outcome.maxAttempts}). Retrying.`,
+      input.activeProject,
+    );
+
+    // Create a new assignment with failure context appended
+    const retryBody = [
+      input.sourceMessage.body,
+      "",
+      `## Verification Failure (attempt ${outcome.attempt}/${outcome.maxAttempts})`,
+      `Command: ${spec.command}`,
+      `Exit code: ${outcome.verifyResult.exitCode}`,
+      "Output:",
+      "```",
+      outcome.verifyResult.output.slice(0, 1000),
+      "```",
+      "",
+      "Fix the issue and try again. The previous changes have been reverted.",
+    ].join("\n");
+
+    // Preserve original assignment attributes (verify, max-attempts, auto-revert, task, launch, scope)
+    const retryAttrs: Record<string, string> = {};
+    const preserveKeys = ["from", "to", "type", "project", "task", "launch", "scope", "verify", "max-attempts", "auto-revert"];
+
+    for (const key of preserveKeys) {
+      const value = input.sourceMessage.attributes[key];
+
+      if (value) {
+        retryAttrs[key] = value;
+      }
+    }
+
+    await createMessageRaw(input.paths.msgDir, retryAttrs, retryBody);
+
+    await appendLogEntry(
+      input.projectPaths.log,
+      "hive supervise verify",
+      `${input.agentId}: ${summary}\nReverted: ${outcome.revertSummary}`,
+    );
+    await appendFeedEntry(input.paths, {
+      project: input.activeProject,
+      headline: `${input.agentId} verify failed, retrying`,
+      details: [
+        `command: ${spec.command}`,
+        `attempt: ${outcome.attempt}/${outcome.maxAttempts}`,
+        `revert: ${outcome.revertSummary}`,
+      ],
+    });
+
+    return { outcome, summary };
+  }
+
+  // action === "block"
+  const summary = `verify FAIL: ${spec.command} (attempt ${outcome.attempt}/${outcome.maxAttempts}, exhausted)`;
+
+  await closeMessage(
+    input.paths.msgDir,
+    input.sourceMessage.filename,
+    "supervisor",
+    `Verification failed after ${outcome.maxAttempts} attempt(s). Blocked for steward review.\nCommand: ${spec.command}\nExit: ${outcome.verifyResult.exitCode}`,
+    input.activeProject,
+  );
+
+  await appendLogEntry(
+    input.projectPaths.log,
+    "hive supervise verify",
+    `${input.agentId}: ${summary}\nReverted: ${outcome.revertSummary}`,
+  );
+  await appendFeedEntry(input.paths, {
+    project: input.activeProject,
+    headline: `${input.agentId} verify exhausted, blocked`,
+    details: [
+      `command: ${spec.command}`,
+      `attempts: ${outcome.maxAttempts}`,
+      `revert: ${outcome.revertSummary}`,
+    ],
+  });
+
+  return { outcome, summary };
+}
+
+function formatVerificationResults(
+  results: { agentId: string; summary: string }[],
+): string {
+  if (results.length === 0) {
+    return "- none";
+  }
+
+  return results.map((r) => `- ${r.agentId}: ${r.summary}`).join("\n");
+}
+
 async function runSupervisorPass(options: SuperviseOptions): Promise<string> {
   const paths = await ensureHiveScaffold();
   const activeProject = await getActiveProject(paths);
@@ -323,6 +479,7 @@ async function runSupervisorPass(options: SuperviseOptions): Promise<string> {
   });
 
   let workerSection = "No worker launches this pass.";
+  const verificationResults: { agentId: string; summary: string }[] = [];
 
   if (dispatch.launches.length > 0) {
     const settled = await Promise.allSettled(
@@ -344,6 +501,28 @@ async function runSupervisorPass(options: SuperviseOptions): Promise<string> {
     workerSection = settled
       .map((result, index) => formatLaunchSettledResult(dispatch.launches[index]!.agentId, result))
       .join("\n");
+
+    // Post-launch verification: check completed workers for verify: specs
+    state = await readProjectState({ activeProject, paths });
+
+    for (const launch of dispatch.launches) {
+      if (!launch.message.attributes.verify) {
+        continue;
+      }
+
+      const result = await verifyCompletedWorker({
+        paths,
+        projectPaths,
+        activeProject,
+        agentId: launch.agentId,
+        sourceMessage: launch.message,
+        allRuns: state.allRuns,
+      });
+
+      if (result) {
+        verificationResults.push({ agentId: launch.agentId, summary: result.summary });
+      }
+    }
   }
 
   const skippedSection =
@@ -351,11 +530,18 @@ async function runSupervisorPass(options: SuperviseOptions): Promise<string> {
       ? dispatch.skipped.map((reason) => `- ${reason}`).join("\n")
       : "- none";
 
-  return [
+  const sections = [
     `Project: ${activeProject}`,
     section("Recovered Runs", formatRecoveredRuns(recoveredRuns)),
     section("Steward", stewardSection),
     section("Worker Launches", workerSection),
+  ];
+
+  if (verificationResults.length > 0) {
+    sections.push(section("Verification", formatVerificationResults(verificationResults)));
+  }
+
+  sections.push(
     section("Skipped Assignments", skippedSection),
     section(
       "Supervisor",
@@ -365,7 +551,9 @@ async function runSupervisorPass(options: SuperviseOptions): Promise<string> {
         `max-parallel: ${options.maxParallel}`,
       ].join("\n"),
     ),
-  ].join("\n\n");
+  );
+
+  return sections.join("\n\n");
 }
 
 export async function superviseCommand(args: string[]): Promise<string> {

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -75,6 +75,61 @@ export function captureGitStatusSnapshot(repoPath: string): GitStatusSnapshot | 
   return parseStatusSnapshot(decode(result.stdout));
 }
 
+export type VerifyCommandResult = {
+  passed: boolean;
+  exitCode: number | null;
+  output: string;
+};
+
+export function runVerifyCommand(repoPath: string, command: string): VerifyCommandResult {
+  const result = Bun.spawnSync({
+    cmd: ["sh", "-c", command],
+    cwd: repoPath,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+
+  const stdout = decode(result.stdout);
+  const stderr = decode(result.stderr);
+  const output = [stdout, stderr].filter(Boolean).join("\n");
+
+  return {
+    passed: result.exitCode === 0,
+    exitCode: result.exitCode,
+    output: output.length > 2000 ? output.slice(-2000) : output,
+  };
+}
+
+export function revertWorkerChanges(repoPath: string): { reverted: boolean; summary: string } {
+  // Discard all unstaged and staged changes, remove untracked files
+  const resetResult = Bun.spawnSync({
+    cmd: ["git", "-C", repoPath, "reset", "--hard", "HEAD"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (resetResult.exitCode !== 0) {
+    return {
+      reverted: false,
+      summary: `git reset --hard failed: ${decode(resetResult.stderr)}`,
+    };
+  }
+
+  const cleanResult = Bun.spawnSync({
+    cmd: ["git", "-C", repoPath, "clean", "-fd"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    reverted: true,
+    summary: cleanResult.exitCode === 0
+      ? "reverted to HEAD (reset --hard + clean -fd)"
+      : `reset succeeded but clean failed: ${decode(cleanResult.stderr)}`,
+  };
+}
+
 export function diffGitStatusSnapshots(
   before: GitStatusSnapshot | null,
   after: GitStatusSnapshot | null,

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -70,6 +70,40 @@ export async function createMessage(
   };
 }
 
+export async function createMessageRaw(
+  msgDir: string,
+  attributes: Record<string, string>,
+  body: string,
+): Promise<HiveMessage> {
+  await mkdir(msgDir, { recursive: true });
+
+  const from = attributes.from ?? "unknown";
+  const to = attributes.to ?? "unknown";
+  const timestamp = toIsoTimestamp();
+  const filename = [
+    toCompactTimestamp(),
+    sanitizeSegment(from),
+    "to",
+    sanitizeSegment(to),
+    crypto.randomUUID().slice(0, 8),
+  ].join("-");
+  const path = join(msgDir, `${filename}.md`);
+  const raw = stringifyFrontmatter(
+    { ...attributes, status: "open", ts: timestamp },
+    body,
+  );
+
+  await Bun.write(path, raw);
+
+  return {
+    path,
+    filename: `${filename}.md`,
+    attributes: parseFrontmatter(raw).attributes,
+    body: body.trim(),
+    raw,
+  };
+}
+
 export async function listMessages(msgDir: string): Promise<HiveMessage[]> {
   const dir = await readdir(msgDir, { withFileTypes: true }).catch(() => []);
   const filenames = dir

--- a/src/lib/supervisor.ts
+++ b/src/lib/supervisor.ts
@@ -1,4 +1,5 @@
 import { parseBoard, minutesSince } from "./board";
+import { revertWorkerChanges, runVerifyCommand, VerifyCommandResult } from "./git";
 import { HiveMessage } from "./messages";
 import {
   extractProjectConfigValue,
@@ -283,6 +284,78 @@ export function selectWorkerLaunches(input: {
   }
 
   return { launches, skipped };
+}
+
+// --- Verification ---
+
+export type VerificationSpec = {
+  command: string;
+  maxAttempts: number;
+  autoRevert: boolean;
+};
+
+export type VerificationOutcome =
+  | { action: "keep"; verifyResult: VerifyCommandResult }
+  | { action: "retry"; attempt: number; maxAttempts: number; verifyResult: VerifyCommandResult; revertSummary: string }
+  | { action: "block"; attempt: number; maxAttempts: number; verifyResult: VerifyCommandResult; revertSummary: string }
+  | { action: "skip"; reason: string };
+
+export function extractVerificationSpec(message: HiveMessage | null): VerificationSpec | null {
+  if (!message) {
+    return null;
+  }
+
+  const verify = message.attributes.verify?.trim();
+
+  if (!verify) {
+    return null;
+  }
+
+  const maxAttempts = Math.max(1, parseInt(message.attributes["max-attempts"] ?? "1", 10) || 1);
+  const autoRevert = (message.attributes["auto-revert"] ?? "true").trim().toLowerCase() !== "false";
+
+  return { command: verify, maxAttempts, autoRevert };
+}
+
+export function countPriorAttempts(
+  sourceMessage: string,
+  historicalRuns: RunRecord[],
+): number {
+  return historicalRuns.filter((run) => run.sourceMessage === sourceMessage).length;
+}
+
+export function runVerification(input: {
+  spec: VerificationSpec;
+  repoPath: string;
+  attempt: number;
+}): VerificationOutcome {
+  const verifyResult = runVerifyCommand(input.repoPath, input.spec.command);
+
+  if (verifyResult.passed) {
+    return { action: "keep", verifyResult };
+  }
+
+  const revert = input.spec.autoRevert
+    ? revertWorkerChanges(input.repoPath)
+    : { reverted: false, summary: "auto-revert disabled" };
+
+  if (input.attempt >= input.spec.maxAttempts) {
+    return {
+      action: "block",
+      attempt: input.attempt,
+      maxAttempts: input.spec.maxAttempts,
+      verifyResult,
+      revertSummary: revert.summary,
+    };
+  }
+
+  return {
+    action: "retry",
+    attempt: input.attempt,
+    maxAttempts: input.spec.maxAttempts,
+    verifyResult,
+    revertSummary: revert.summary,
+  };
 }
 
 export function assessRecoveredRuns(

--- a/tests/verification.test.ts
+++ b/tests/verification.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  countPriorAttempts,
+  extractVerificationSpec,
+  runVerification,
+} from "../src/lib/supervisor";
+import { HiveMessage } from "../src/lib/messages";
+import { RunRecord } from "../src/lib/runs";
+
+function makeMessage(attrs: Record<string, string>): HiveMessage {
+  return {
+    path: "/tmp/test.md",
+    filename: "test.md",
+    attributes: {
+      from: "orchestrator",
+      to: "alpha",
+      type: "assign",
+      status: "open",
+      project: "myproject",
+      ...attrs,
+    },
+    body: "Do the thing.",
+    raw: "",
+  };
+}
+
+function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    runId: "20260310-140000Z-alpha",
+    projectId: "myproject",
+    agentId: "alpha",
+    status: "exited",
+    runtime: "claude",
+    model: null,
+    started: "2026-03-10T14:00:00Z",
+    ended: "2026-03-10T14:05:00Z",
+    exitCode: 0,
+    pid: null,
+    promptPath: "/tmp/alpha.prompt.md",
+    source: "hive supervise",
+    sourceMessage: "test.md",
+    taskId: null,
+    scope: ["src/api"],
+    stopRequestedAt: null,
+    stopRequestedBy: null,
+    path: "/tmp/alpha/run.md",
+    ...overrides,
+  };
+}
+
+describe("extractVerificationSpec", () => {
+  test("returns null when no verify attribute", () => {
+    const msg = makeMessage({});
+
+    expect(extractVerificationSpec(msg)).toBeNull();
+  });
+
+  test("returns null for null message", () => {
+    expect(extractVerificationSpec(null)).toBeNull();
+  });
+
+  test("extracts verify command with defaults", () => {
+    const msg = makeMessage({ verify: "bun test" });
+    const spec = extractVerificationSpec(msg);
+
+    expect(spec).toEqual({
+      command: "bun test",
+      maxAttempts: 1,
+      autoRevert: true,
+    });
+  });
+
+  test("extracts all fields", () => {
+    const msg = makeMessage({
+      verify: "npm test -- --bail",
+      "max-attempts": "3",
+      "auto-revert": "true",
+    });
+    const spec = extractVerificationSpec(msg);
+
+    expect(spec).toEqual({
+      command: "npm test -- --bail",
+      maxAttempts: 3,
+      autoRevert: true,
+    });
+  });
+
+  test("auto-revert defaults to true", () => {
+    const msg = makeMessage({ verify: "bun test" });
+
+    expect(extractVerificationSpec(msg)!.autoRevert).toBeTrue();
+  });
+
+  test("auto-revert can be disabled", () => {
+    const msg = makeMessage({ verify: "bun test", "auto-revert": "false" });
+
+    expect(extractVerificationSpec(msg)!.autoRevert).toBeFalse();
+  });
+
+  test("max-attempts defaults to 1", () => {
+    const msg = makeMessage({ verify: "bun test" });
+
+    expect(extractVerificationSpec(msg)!.maxAttempts).toBe(1);
+  });
+
+  test("max-attempts floors to 1", () => {
+    const msg = makeMessage({ verify: "bun test", "max-attempts": "0" });
+
+    expect(extractVerificationSpec(msg)!.maxAttempts).toBe(1);
+  });
+});
+
+describe("countPriorAttempts", () => {
+  test("returns 0 when no matching runs", () => {
+    expect(countPriorAttempts("test.md", [])).toBe(0);
+  });
+
+  test("counts matching source messages", () => {
+    const runs = [
+      makeRun({ sourceMessage: "test.md", runId: "run-1" }),
+      makeRun({ sourceMessage: "test.md", runId: "run-2" }),
+      makeRun({ sourceMessage: "other.md", runId: "run-3" }),
+    ];
+
+    expect(countPriorAttempts("test.md", runs)).toBe(2);
+  });
+});
+
+describe("runVerification", () => {
+  test("returns keep when command passes", () => {
+    const outcome = runVerification({
+      spec: { command: "true", maxAttempts: 3, autoRevert: true },
+      repoPath: "/tmp",
+      attempt: 1,
+    });
+
+    expect(outcome.action).toBe("keep");
+
+    if (outcome.action === "keep") {
+      expect(outcome.verifyResult.passed).toBeTrue();
+      expect(outcome.verifyResult.exitCode).toBe(0);
+    }
+  });
+
+  test("returns retry when command fails and attempts remain", () => {
+    const outcome = runVerification({
+      spec: { command: "false", maxAttempts: 3, autoRevert: false },
+      repoPath: "/tmp",
+      attempt: 1,
+    });
+
+    expect(outcome.action).toBe("retry");
+
+    if (outcome.action === "retry") {
+      expect(outcome.attempt).toBe(1);
+      expect(outcome.maxAttempts).toBe(3);
+      expect(outcome.verifyResult.passed).toBeFalse();
+    }
+  });
+
+  test("returns block when command fails and attempts exhausted", () => {
+    const outcome = runVerification({
+      spec: { command: "false", maxAttempts: 2, autoRevert: false },
+      repoPath: "/tmp",
+      attempt: 2,
+    });
+
+    expect(outcome.action).toBe("block");
+
+    if (outcome.action === "block") {
+      expect(outcome.attempt).toBe(2);
+      expect(outcome.maxAttempts).toBe(2);
+    }
+  });
+
+  test("captures verify command output", () => {
+    const outcome = runVerification({
+      spec: { command: "echo 'hello from verify'", maxAttempts: 1, autoRevert: false },
+      repoPath: "/tmp",
+      attempt: 1,
+    });
+
+    expect(outcome.action).toBe("keep");
+
+    if (outcome.action === "keep") {
+      expect(outcome.verifyResult.output).toContain("hello from verify");
+    }
+  });
+
+  test("captures failing command output", () => {
+    const outcome = runVerification({
+      spec: { command: "echo 'test failed' && exit 1", maxAttempts: 1, autoRevert: false },
+      repoPath: "/tmp",
+      attempt: 1,
+    });
+
+    expect(outcome.action).toBe("block");
+
+    if (outcome.action === "block") {
+      expect(outcome.verifyResult.output).toContain("test failed");
+      expect(outcome.verifyResult.exitCode).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a verification workflow that allows supervisor to run verification commands on completed worker assignments and handle failures through retry or blocking mechanisms.

## Key Changes

- **New verification spec extraction**: Added `extractVerificationSpec()` to parse `verify`, `max-attempts`, and `auto-revert` attributes from assignment messages
- **Verification execution**: Implemented `runVerification()` to execute verification commands and determine outcomes (keep/retry/block)
- **Git integration**: Added `runVerifyCommand()` and `revertWorkerChanges()` to run verification scripts and revert changes on failure
- **Retry workflow**: When verification fails with attempts remaining, supervisor closes the original assignment and creates a new one with failure context and reverted changes
- **Blocking mechanism**: When max attempts are exhausted, supervisor closes the assignment for steward review
- **Supervisor integration**: Updated `runSupervisorPass()` to run post-launch verification on completed workers and report results
- **Message utilities**: Added `createMessageRaw()` to create assignment messages with custom attributes and body
- **Comprehensive test coverage**: Added 205 lines of tests covering all verification functions

## Implementation Details

- Verification commands are executed via shell in the repository path
- Command output is captured and truncated to last 2000 chars if needed
- Failed verification automatically reverts worker changes via `git reset --hard` and `git clean -fd` (unless `auto-revert: false`)
- Retry assignments preserve original attributes (verify, max-attempts, auto-revert, task, launch, scope) and append failure context
- Verification results are logged and added to project feed for visibility
- Attempt counting is based on matching source message filename across historical runs

https://claude.ai/code/session_01KHoi6SNHyzCEngdQAnpsx7