### PR TITLE
Add design documents for steward and state refactoring

### DIFF
--- a/docs/SIMPLIFY-COMMAND-SURFACE.md
+++ b/docs/SIMPLIFY-COMMAND-SURFACE.md
@@ -1,0 +1,228 @@
+# Command Surface Consolidation
+
+Design document. March 2026.
+
+---
+
+## Problem
+
+HIVE has 28+ commands. Several overlap significantly, others are internal
+primitives that shouldn't be top-level, and the overall surface is hard to
+hold in your head. A CLI that requires a cheat sheet has too many commands.
+
+The control surface should be obvious. A new user should be able to guess
+what command they need.
+
+---
+
+## Current Command Inventory
+
+```
+Setup:        init, project, work
+Front door:   run, say, ask, console, chat, gateway
+Supervision:  supervise, launch, ps, stop
+Coordination: msg, nudge, inbox, status, log, approval
+Observation:  feed, watch, events
+Inspection:   prompt, runtimes, cognition
+Maintenance:  memory, sync, archive
+Meta:         help, orchestrate
+```
+
+That's 28 commands across 8 categories. Too many.
+
+---
+
+## Identified Overlaps
+
+### Group 1: Interactive Sessions — chat, console, orchestrate
+
+All three load soul/config/board/memory context, build a prompt, and call an
+LLM runtime.
+
+- `chat`: single-turn LLM call with full hive context
+- `console`: multi-turn interactive session with run ledger tracking
+- `orchestrate`: steward prompt assembly, supports `--mode interactive|loop`
+
+**The difference is mode, not function.** These are one command with flags.
+
+### Group 2: Message Queueing — say, nudge, msg
+
+- `say`: creates a goal message, auto-starts supervisor
+- `nudge`: creates a nudge message from human to orchestrator
+- `msg`: general message CRUD with type, from, to, body
+
+`say` is `msg --type goal human orchestrator <body>` + auto-start.
+`nudge` is `msg --type nudge human orchestrator <body>`.
+
+### Group 3: Supervision — run, supervise
+
+- `run`: starts detached supervisor with interval/max-parallel options
+- `supervise`: full supervisor with `--once`, `--detach`, `status`, `stop`,
+  `logs` subcommands
+
+`run` is `supervise --detach` with slightly different defaults. Two commands
+for the same subsystem is confusing.
+
+### Group 4: Status/Observation — ask, status, watch, feed, events, ps
+
+Six commands for "what's happening?" Each shows a different slice:
+
+- `ask` (no args): fast digest of board + messages + runs
+- `status`: board + open messages formatted for terminal
+- `watch`: live polling console
+- `feed`: recent feed entries
+- `events`: event history
+- `ps`: active and recent runs
+
+These are genuinely different views, but the user shouldn't need to memorize
+which shows what.
+
+---
+
+## Proposed Consolidated Surface
+
+### Tier 1: Daily Commands (the front door)
+
+These are the commands a user types every day.
+
+```
+hive run [goal]              # Start the hive. Optional goal auto-queued.
+hive say <message>           # Talk to the hive (queues message, ensures running)
+hive ask [question]          # What's happening? (no args = digest, with args = LLM)
+hive stop [agent|run]        # Stop something (no args = stop supervision)
+hive console [--runtime]     # Interactive session with the hive
+hive gateway [--port]        # Web interface
+```
+
+Six commands. Memorable.
+
+### Tier 2: Operator Commands
+
+For when you need more control.
+
+```
+hive status                  # Detailed board + messages + runs
+hive watch [--interval]      # Live polling console
+hive ps                      # Process/run listing
+hive msg <from> <to> <body>  # Direct message (absorbs nudge)
+hive msg show|resolve|close  # Message lifecycle
+hive launch <agent> [goal]   # Manual worker launch
+hive log <message>           # Append to LOG.md
+hive feed [count]            # Event feed
+hive inbox [agent]           # Agent message queue
+```
+
+Nine commands. Each does one clear thing.
+
+### Tier 3: Setup & Maintenance
+
+```
+hive init                    # Bootstrap ~/.hive/
+hive project add <path>      # Register project
+hive work [project]          # Set/show active project
+hive memory                  # Memory management
+hive archive                 # Archive session
+hive sync                    # PLAN.md → repo
+```
+
+Six commands. Used infrequently.
+
+### Tier 4: Inspection & Debug
+
+```
+hive prompt <agent>          # Show assembled prompt
+hive runtimes                # List runtime adapters
+hive cognition               # Cognitive routing policy
+hive events                  # Event log
+```
+
+Four commands. Debugging tools.
+
+**Total: 25 commands.** Down from 28+.
+
+---
+
+## What Gets Absorbed
+
+| Removed     | Absorbed Into           | Rationale                                |
+|-------------|-------------------------|------------------------------------------|
+| `nudge`     | `msg`                   | `nudge` is `msg --type nudge human orch` |
+| `chat`      | `console --once`        | Single-turn is a mode of console         |
+| `orchestrate` | internal only          | Prompt assembly is not a user command    |
+| `supervise` | `run` (with subcommands) | `run status`, `run logs`, `run stop`    |
+| `approval`  | `msg` type or deferred  | Not wired as enforcement gate yet        |
+
+---
+
+## Migration: `run` Absorbs `supervise`
+
+Today `run` is thin and `supervise` is the real implementation. Flip this:
+
+```
+hive run                     # Start supervision (current behavior)
+hive run status              # Show supervisor state
+hive run stop                # Stop supervisor
+hive run logs                # Show supervisor logs
+hive run --once              # Single supervisor pass
+```
+
+The `supervise` command becomes an alias during transition, then removed.
+
+---
+
+## Migration: `console` Absorbs `chat`
+
+```
+hive console                 # Interactive multi-turn session (default)
+hive console --once <msg>    # Single-turn (replaces chat)
+hive console --runtime X     # Runtime override (already exists)
+hive console --dry-run       # Show prompt without executing
+```
+
+`chat` becomes an alias during transition, then removed.
+
+---
+
+## Migration: `msg` Absorbs `nudge`
+
+```
+hive msg human orchestrator "look at the tests"        # Direct message
+hive msg --type nudge human orchestrator "check board"  # Explicit nudge
+hive say "fix the tests"                                # Unchanged (goal + auto-start)
+```
+
+`nudge` becomes an alias for `msg --type nudge human orchestrator`.
+
+---
+
+## Implementation Order
+
+1. **Add subcommands to `run`** — `run status|stop|logs` delegate to
+   supervisor internals. Keep `supervise` as alias.
+
+2. **Add `--once` to `console`** — single-turn mode using chat's prompt
+   logic. Keep `chat` as alias.
+
+3. **Absorb `nudge` into `msg`** — add `--type nudge` shorthand.
+   Keep `nudge` as alias.
+
+4. **Remove `orchestrate` from CLI routing** — keep the function for
+   internal use (gateway, steward prompt building).
+
+5. **After burn-in** — remove aliases, update help text, update CLAUDE.md.
+
+---
+
+## Design Rules for Future Commands
+
+1. **Does it need top-level status?** If a command is used less than weekly,
+   it should be a subcommand or flag, not a top-level command.
+
+2. **Can the user guess it?** If you need to explain the difference between
+   two commands, they should be one command.
+
+3. **One subsystem, one command.** Supervision is `run`. Messages are `msg`.
+   Sessions are `console`. Don't split a subsystem across multiple commands.
+
+4. **Subcommands over new commands.** `run stop` not `stop-supervisor`.
+   `msg resolve` not `resolve-msg`.

--- a/docs/SIMPLIFY-PERSISTENT-STEWARD.md
+++ b/docs/SIMPLIFY-PERSISTENT-STEWARD.md
@@ -1,0 +1,438 @@
+# Persistent Steward: Reimagination
+
+Design document. March 2026.
+
+Builds on PERSISTENT-STEWARD-RUNTIME.md and PERSISTENT-STEWARD-DESIGN.md.
+
+---
+
+## Current State
+
+The persistent steward works. It runs as a Pi subprocess spawned by the
+gateway, communicates via JSON-over-stdout RPC, manages session files,
+handles streaming events, idle timeouts, retry logic, and crash recovery.
+
+It is also the most fragile piece of critical infrastructure in HIVE.
+
+`persistent-steward.ts` is 1,391 lines. The core complexity is not in the
+steward's *thinking* — it's in managing a child process:
+
+- `handlePiLine`: 140-line switch statement parsing JSON events from stdout
+- `wirePersistentStewardStreams`: manual stdout buffering and line splitting
+- `sendPiCommand` / `waitForPersistentTurnCompletion`: custom RPC with
+  timeout management and command correlation via IDs
+- `acquirePersistentStewardHandle`: process lifecycle, spawn, retry on
+  permission errors, global handle maps
+- `disposePersistentStewardHandle`: cleanup, pending command rejection
+- `scheduleIdleShutdown` / `clearIdleTimer`: idle timeout scheduling
+
+~600 lines of this file are child process management. The actual steward
+intelligence — context loading, prompt building, delta handling — is
+~400 lines (and much of that is duplicated from `steward.ts`).
+
+### What's Fragile
+
+1. **String protocol parsing.** The Pi RPC protocol is JSON-over-stdout
+   with manual line buffering. If Pi changes its event format, HIVE breaks
+   silently. There are no schema checks — just `as` casts on parsed JSON.
+
+2. **Global mutable state.** `persistentStewardHandles` is a module-level
+   Map of live process handles keyed by project+session. Multiple code paths
+   read and mutate these handles concurrently.
+
+3. **Recovery is manual.** If the Pi process crashes, the handle is cleaned
+   up and the next request falls back to one-shot. But there's no automatic
+   re-bootstrap — the steward loses its conversation context.
+
+4. **Tight coupling to Pi's CLI.** The spawn args (`--mode rpc`,
+   `--session`, `--system-prompt`, `--tools`, `--no-extensions`, etc.) and
+   the event types (`agent_start`, `agent_end`, `turn_end`,
+   `message_update`, `auto_retry_start`) are hardcoded to Pi's current
+   interface. This is an implicit contract with no version negotiation.
+
+5. **The steward is not disposable.** HIVE's core principle is that agents
+   are disposable. But the persistent steward is the one agent that
+   accumulates session state in a subprocess and can't be trivially
+   restarted. This contradicts the architecture.
+
+---
+
+## The Core Insight
+
+The PERSISTENT-STEWARD-DESIGN.md identifies the right architecture:
+
+> Pi is the session engine for the persistent steward.
+> The boundary is sharp: Pi owns one live steward session.
+> HIVE owns everything else.
+
+But the current implementation inverts this. HIVE owns the process
+lifecycle, the stream parsing, the RPC protocol, the error recovery. Pi is
+treated as a dumb subprocess, not a session engine. HIVE does Pi's job
+badly instead of letting Pi do it well.
+
+The design doc also shows the right integration pattern:
+
+```typescript
+const agent = new Agent({
+  initialState: { systemPrompt, model, tools, messages },
+  transformContext: async (messages, signal) => { ... },
+});
+agent.subscribe((event) => { ... });
+await agent.prompt(message);
+```
+
+This is in-process. No subprocess. No stdout parsing. No RPC. The Agent
+class from `@mariozechner/pi-agent-core` is a library, not a CLI.
+
+---
+
+## Proposed Architecture
+
+### Use Pi as a Library, Not a Subprocess
+
+Replace the child process spawn with direct in-process usage of
+`@mariozechner/pi-agent-core` and `@mariozechner/pi-ai`.
+
+This eliminates:
+- All stdout/stderr buffering and line parsing
+- The entire RPC command/response correlation system
+- Process lifecycle management (spawn, exit handlers, idle timers)
+- The global `persistentStewardHandles` map
+- Retry-on-permission-error logic for process spawning
+- ~600 lines of process management code
+
+What remains:
+- A `StewardSession` object that wraps a Pi `Agent` instance
+- Context loading via shared `steward-context.ts`
+- Gateway integration via `agent.subscribe()` → WebSocket broadcast
+- Clean model swapping, steering, and follow-up via the Agent API
+
+### The New `persistent-steward.ts`
+
+After this change plus the steward-context unification, the file should be
+~300-400 lines:
+
+```typescript
+import { Agent, AgentTool } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+import { loadStewardContext, renderStewardIdentityBlock } from "./steward-context";
+
+type StewardSession = {
+  agent: Agent;
+  projectId: string;
+  sessionId: string;
+  revision: number;
+  createdAt: number;
+};
+
+// One live session per project
+const sessions = new Map<string, StewardSession>();
+
+export async function ensureStewardSession(
+  paths: HivePaths,
+  projectId: string,
+  sessionId: string,
+): Promise<StewardSession> {
+  const existing = sessions.get(projectId);
+  if (existing?.sessionId === sessionId) return existing;
+
+  const ctx = await loadStewardContext(paths, projectId, sessionId);
+  const model = resolveModel(ctx);
+
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: buildSystemPrompt(ctx),
+      model,
+      tools: buildStewardTools(paths, projectId),
+      messages: ctx.recentTurns.length
+        ? reconstructConversation(ctx.recentTurns)
+        : [],
+    },
+    transformContext: async (messages) => {
+      // Inject latest delta, prune old context
+      const delta = await loadStewardRefreshDelta(paths, projectId, ctx.revision);
+      return applyContextContract(messages, delta);
+    },
+  });
+
+  const session: StewardSession = {
+    agent,
+    projectId,
+    sessionId,
+    revision: ctx.revision,
+    createdAt: Date.now(),
+  };
+
+  sessions.set(projectId, session);
+  return session;
+}
+
+export async function runPersistentStewardTurn(
+  session: StewardSession,
+  humanMessage: string,
+  onEvent?: (event: AgentEvent) => void,
+): Promise<StewardTurnResult> {
+  if (onEvent) {
+    session.agent.subscribe(onEvent);
+  }
+
+  await session.agent.prompt(humanMessage);
+
+  const lastMessage = session.agent.state.messages.at(-1);
+  // ... extract text, usage, record turn
+}
+
+export function disposeStewardSession(projectId: string): void {
+  const session = sessions.get(projectId);
+  if (session) {
+    session.agent.abort();
+    sessions.delete(projectId);
+  }
+}
+```
+
+### Steward Tools
+
+The steward's tools become Pi `AgentTool` objects registered at session
+creation. These replace the runtime CLI's built-in tools with HIVE-aware
+equivalents:
+
+```typescript
+function buildStewardTools(paths: HivePaths, projectId: string): AgentTool[] {
+  return [
+    {
+      name: "read_board",
+      description: "Read current BOARD.md",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        result: await Bun.file(getProjectPaths(paths, projectId).board).text(),
+      }),
+    },
+    {
+      name: "assign_worker",
+      description: "Create a worker assignment",
+      parameters: Type.Object({
+        agent: Type.String(),
+        task: Type.String(),
+        scope: Type.Optional(Type.String()),
+      }),
+      execute: async ({ agent, task, scope }) => {
+        await createMessage({ from: "steward", to: agent, type: "assignment", body: task, scope });
+        return { result: `Assigned to ${agent}` };
+      },
+    },
+    {
+      name: "read_file",
+      description: "Read a hive or project file",
+      parameters: Type.Object({ path: Type.String() }),
+      execute: async ({ path }) => ({
+        result: await Bun.file(path).text(),
+      }),
+    },
+    {
+      name: "update_board",
+      description: "Write updated BOARD.md content",
+      parameters: Type.Object({ content: Type.String() }),
+      execute: async ({ content }) => {
+        await Bun.write(getProjectPaths(paths, projectId).board, content);
+        return { result: "Board updated" };
+      },
+    },
+  ];
+}
+```
+
+### Context Contract via `transformContext`
+
+This is where the bootstrap/refresh distinction lives:
+
+```typescript
+transformContext: async (messages) => {
+  // Keep system prompt and recent conversation window
+  const recent = messages.slice(-MAX_CONTEXT_MESSAGES);
+
+  // Check for state changes since last turn
+  const delta = await loadStewardRefreshDelta(paths, projectId, session.revision);
+
+  if (delta.changes.length > 0) {
+    // Inject compact delta as a system-like message
+    recent.push({
+      role: "user",
+      content: `[HIVE state update — revision ${delta.revision}]\n${formatDelta(delta)}`,
+      timestamp: Date.now(),
+    });
+    session.revision = delta.revision;
+  }
+
+  return recent;
+}
+```
+
+The first turn gets the full bootstrap context (via systemPrompt + initial
+messages). Subsequent turns get only deltas via `transformContext`. This
+matches the design doc's context contract exactly.
+
+### Gateway Integration
+
+The gateway wiring becomes straightforward:
+
+```typescript
+// In /api/console/send handler
+async function handleConsoleSend(message: string, sessionId: string, projectId: string) {
+  try {
+    const session = await ensureStewardSession(paths, projectId, sessionId);
+
+    await runPersistentStewardTurn(session, message, (event) => {
+      // Stream events to WebSocket clients
+      if (event.type === "text_delta") {
+        broadcast({ type: "console-response", data: { delta: event.text } });
+      }
+      if (event.type === "tool_execution_start") {
+        broadcast({ type: "steward-tool", data: { tool: event.toolName } });
+      }
+    });
+  } catch (err) {
+    // Session died — dispose and fall back to one-shot
+    disposeStewardSession(projectId);
+    return runDirectStewardTurn(message);
+  }
+}
+
+// Human interrupts mid-turn
+async function handleSteeringMessage(message: string, projectId: string) {
+  const session = sessions.get(projectId);
+  if (session) {
+    session.agent.steer({ role: "user", content: message, timestamp: Date.now() });
+  }
+}
+```
+
+No process management. No stdout parsing. No RPC timeouts.
+
+### Crash Recovery
+
+When the steward session fails (provider error, OOM, bug):
+
+1. `disposeStewardSession` cleans up the Agent instance
+2. Next request calls `ensureStewardSession` which re-bootstraps
+3. Bootstrap loads conversation tail from session history files
+4. The steward picks up where it left off
+
+This is genuinely disposable. The steward can die and restart without
+losing durable state because all durable state is in files — exactly
+matching HIVE's core principle.
+
+---
+
+## What Changes
+
+| Aspect                    | Current (subprocess)        | Proposed (in-process)        |
+|--------------------------|---------------------------- |------------------------------|
+| Pi integration           | Child process + RPC         | Library import               |
+| Streaming                | stdout line parsing         | `agent.subscribe()`          |
+| Session lifecycle        | Global handle map           | Simple Map of Agent objects  |
+| Crash recovery           | Manual, lossy               | Automatic re-bootstrap       |
+| Process management       | 600 lines                   | 0 lines                     |
+| Idle timeout             | Timer-based process kill    | Agent garbage collection     |
+| Auth/model routing       | CLI args to subprocess      | `getModel()` API call        |
+| Steering/interrupts      | RPC command                 | `agent.steer()` method       |
+| Tool execution           | Pi's built-in tools         | HIVE-registered AgentTools   |
+| Total file size          | ~1,400 lines                | ~300-400 lines               |
+
+---
+
+## Dependencies
+
+### Required First
+
+1. **Steward context unification** (SIMPLIFY-STEWARD-UNIFICATION.md) —
+   shared context loading must exist before both steward modes can consume
+   it cleanly.
+
+2. **Pi library availability** — confirm `@mariozechner/pi-agent-core` and
+   `@mariozechner/pi-ai` can be used as direct imports in a Bun project
+   without the CLI wrapper.
+
+### Nice to Have First
+
+3. **State decomposition** (SIMPLIFY-STATE-DECOMPOSITION.md) — cleaner
+   delta loading makes the `transformContext` callback simpler.
+
+---
+
+## Migration Path
+
+### Phase 1: Verify Pi Library Integration
+
+Add `@mariozechner/pi-agent-core` and `@mariozechner/pi-ai` as
+dependencies. Write a minimal test: create an Agent, send a prompt, receive
+a response. Confirm it works in Bun without the CLI.
+
+This is the key risk gate. If the libraries don't work as in-process
+imports (e.g., they assume CLI context, or have incompatible dependencies),
+this approach needs adjustment.
+
+### Phase 2: Build New Persistent Steward
+
+Write the new `persistent-steward.ts` alongside the existing one (e.g., as
+`persistent-steward-v2.ts`). Use the shared `steward-context.ts` for
+context loading. Wire up gateway integration behind a feature flag
+(`HIVE_STEWARD_V2=1`).
+
+### Phase 3: Gateway Cutover
+
+Switch the gateway from subprocess-based to in-process steward. Keep the
+old code available as fallback behind the inverse flag.
+
+### Phase 4: Remove Old Implementation
+
+Once the new implementation is stable, delete the subprocess-based code
+and the global handle maps.
+
+---
+
+## What This Does NOT Change
+
+- The one-shot `steward.ts` path remains as fallback and for CLI usage
+- Worker execution remains via runtime adapters (no Pi dependency)
+- The file substrate, supervisor, and state monitor are unchanged
+- The gateway's other responsibilities (supervisor, WebSocket, static
+  assets) are unaffected
+
+---
+
+## Risk: Zero-Dependency Constraint
+
+HIVE currently has zero npm dependencies. Adding Pi as a library dependency
+breaks that constraint.
+
+Options:
+
+1. **Accept the dependency.** Pi is a known, controlled dependency
+   (authored by a collaborator). It provides genuine value that would be
+   expensive to reimplement. The zero-dep constraint was about avoiding
+   dependency hell, not about purity.
+
+2. **Vendor Pi.** Copy the relevant modules into HIVE's tree. Maintains
+   zero external deps but creates a maintenance burden.
+
+3. **Keep subprocess but clean it up.** If the zero-dep constraint is
+   sacred, the alternative is to heavily refactor the existing subprocess
+   approach — extract the RPC protocol into a clean module, add schema
+   validation, reduce the handle management complexity. This is less
+   transformative but preserves the constraint.
+
+Recommendation: option 1. The zero-dep principle served its purpose during
+bootstrap. Pi is a strategic dependency, not an incidental one.
+
+---
+
+## Success Criteria
+
+1. The persistent steward runs in-process, not as a subprocess.
+2. No stdout/stderr parsing anywhere in the steward path.
+3. `persistent-steward.ts` is under 400 lines.
+4. Steward crash → automatic re-bootstrap from files on next request.
+5. Human-perceived latency for first response is faster (no process spawn).
+6. All existing gateway console functionality works unchanged.
+7. The steward is genuinely disposable — kill it, restart it, no state loss.

--- a/docs/SIMPLIFY-STATE-DECOMPOSITION.md
+++ b/docs/SIMPLIFY-STATE-DECOMPOSITION.md
@@ -1,0 +1,176 @@
+# State Module Decomposition
+
+Design document. March 2026.
+
+---
+
+## Problem
+
+`state.ts` is 983 lines and does eight jobs:
+
+1. Define all summary types (BoardSummary, OpenMessagesSummary, etc.)
+2. Parse task status from markdown lines
+3. Summarize board, messages, runs, sessions, inbox
+4. Read/write JSON state files
+5. Compute content fingerprints for change detection
+6. Build delta packets (what changed since last steward look)
+7. Maintain delta history (append-only log)
+8. Orchestrate the full refresh cycle (`refreshProjectRuntimeState`)
+
+The main function `refreshProjectRuntimeState` is ~180 lines of interleaved
+reads, summarization, fingerprinting, delta computation, and writes with no
+clear boundaries between concerns. It's hard to test any piece in isolation.
+
+Additionally, key functions are duplicated across files:
+
+- `parseTaskStatus` exists in `state.ts`, `supervisor.ts`, and `digest.ts`
+  with subtly different behavior (state.ts checks for "pending", digest.ts
+  does not)
+- `normalizeInlineText` and `truncate` are duplicated between `state.ts` and
+  `persistent-steward.ts`
+- `isRealBlocker` is duplicated between `state.ts` and `digest.ts`
+
+This is a bug factory. Different parsing of the same task status format in
+different files means the supervisor and the state monitor can disagree about
+what's active.
+
+---
+
+## Proposed Decomposition
+
+### New File: `src/lib/text.ts`
+
+Shared text utilities. Single source of truth.
+
+```
+normalizeInlineText(value: string): string
+truncate(value: string, max?: number): string
+firstLine(value: string): string
+```
+
+Every file that needs text normalization imports from here.
+
+### New File: `src/lib/board-parse.ts`
+
+Consolidate all board/task parsing into one place. The existing `board.ts`
+handles section extraction (tasks, agents, blockers, decisions). This new
+file handles task-line parsing:
+
+```
+parseTaskStatus(line: string): string | null
+parseTaskId(line: string): string | null
+isRealBlocker(line: string): boolean
+```
+
+These are currently scattered across `state.ts`, `digest.ts`, and
+`supervisor.ts`. One implementation, one set of tests, one behavior.
+
+### Existing File: `src/lib/digest.ts` — Unchanged Role
+
+Already exports `digestBoard`, `digestMessages`, `digestRuns`. These produce
+human-readable markdown digests for prompts. Keep as-is, but have them
+import from `board-parse.ts` instead of defining their own `parseTaskStatus`.
+
+### Refactored: `src/lib/state.ts` — Narrowed to State I/O
+
+After extraction, `state.ts` retains:
+
+1. **Type definitions** — BoardSummary, OpenMessagesSummary, etc.
+2. **Summarization functions** — `summarizeBoard`, `summarizeMessages`,
+   `summarizeRuns`, `summarizeActiveRuns`, `summarizeInbox`,
+   `summarizeSession`. Each is a pure function: raw data in, summary out.
+3. **JSON I/O** — `readJson`, `writeJson`, `appendJsonLine`,
+   `ensureStateFiles`. File system helpers for the state directory.
+
+Removed from `state.ts`:
+
+- Text utilities → `text.ts`
+- Task parsing → `board-parse.ts`
+- Fingerprinting → `state-delta.ts`
+- Delta computation → `state-delta.ts`
+- The refresh orchestrator → `state-refresh.ts`
+
+### New File: `src/lib/state-delta.ts`
+
+Owns change detection and delta computation:
+
+```
+hashJson(value: unknown): string
+buildBoardChange(prev, next): StewardDeltaChange | null
+buildMessageChanges(prev, next): StewardDeltaChange[]
+buildResultChanges(prev, next): StewardDeltaChange[]
+buildRunChanges(prev, next): StewardDeltaChange[]
+buildSessionChanges(prev, next): StewardDeltaChange[]
+buildDeltaPacket(prev, next): StewardDeltaPacket
+```
+
+All pure functions. Testable without file I/O.
+
+### New File: `src/lib/state-refresh.ts`
+
+The orchestrator. Imports from `state.ts`, `state-delta.ts`, and the raw
+data loaders (`runs.ts`, `messages.ts`, `sessions.ts`, `board.ts`).
+
+```
+refreshProjectRuntimeState(paths, project, options?): ProjectRefreshResult
+readStewardDeltaHistory(paths, project, since?): DeltaHistoryEntry[]
+```
+
+This is the only file that does I/O in the state subsystem. It:
+
+1. Reads raw data from disk (board, messages, runs, sessions)
+2. Calls summarizers from `state.ts`
+3. Calls delta builders from `state-delta.ts`
+4. Writes derived state JSON to the state directory
+5. Returns the refresh result
+
+---
+
+## File Inventory After Decomposition
+
+| File               | Lines (est.) | Responsibility              |
+|--------------------|--------------|-----------------------------|
+| `text.ts`          | ~20          | Text normalization          |
+| `board-parse.ts`   | ~60          | Task line parsing           |
+| `state.ts`         | ~400         | Types + summarizers + JSON  |
+| `state-delta.ts`   | ~250         | Change detection            |
+| `state-refresh.ts` | ~250         | Refresh orchestration       |
+| `digest.ts`        | ~100         | Prompt digest rendering     |
+
+Total: ~1080 lines across 6 files vs. 983 in one file. Slightly more code
+from explicit imports, but each file has one job and is independently
+testable.
+
+---
+
+## Migration Steps
+
+1. **Extract `text.ts`** — move `normalizeInlineText`, `truncate`,
+   `firstLine`. Update all importers. Delete duplicates in
+   `persistent-steward.ts`.
+
+2. **Extract `board-parse.ts`** — move `parseTaskStatus`, `parseTaskId`,
+   `isRealBlocker`. Update `state.ts`, `digest.ts`, `supervisor.ts`.
+   **Fix the "pending" divergence** — one canonical behavior.
+
+3. **Extract `state-delta.ts`** — move `hashJson`, all `build*Change`
+   functions, `buildDeltaPacket`, and the `StewardDeltaPacket` /
+   `StewardDeltaChange` types.
+
+4. **Extract `state-refresh.ts`** — move `refreshProjectRuntimeState`
+   and `readStewardDeltaHistory`.
+
+5. **Update tests** — existing `state.test.ts` should split into
+   `state.test.ts` (summarizers), `state-delta.test.ts` (change detection),
+   `state-refresh.test.ts` (integration).
+
+---
+
+## Success Criteria
+
+1. `parseTaskStatus` exists in exactly one file.
+2. `normalizeInlineText` and `truncate` exist in exactly one file.
+3. Every summarizer is a pure function testable without disk I/O.
+4. Every delta builder is a pure function testable without disk I/O.
+5. `refreshProjectRuntimeState` is the only function that touches disk.
+6. All existing tests pass unchanged.

--- a/docs/SIMPLIFY-STEWARD-UNIFICATION.md
+++ b/docs/SIMPLIFY-STEWARD-UNIFICATION.md
@@ -1,0 +1,233 @@
+# Steward Abstraction Unification
+
+Design document. March 2026.
+
+---
+
+## Problem
+
+The steward — the live head of the hive — is implemented twice:
+
+- `steward.ts` (553 lines): direct one-shot steward turns via CLI runtime
+- `persistent-steward.ts` (1,391 lines): Pi-backed persistent session
+
+These files share the same goal (run a steward turn with full hive context)
+but share almost no code. The result is:
+
+1. **Duplicated rendering** — `renderRecentTurns`, `renderDeltaHistory`,
+   `renderRecentResultsDigest`, `renderHumanInboxDigest`, and
+   `loadDeltaHistory` are copy-pasted identically across both files.
+
+2. **Duplicated context loading** — both files independently load soul,
+   identity, board, messages, runs, sessions, memory, and cognitive routing
+   policy. They produce slightly different context types
+   (`StewardPromptContext` vs `PersistentStewardContext`) that carry the
+   same data.
+
+3. **Duplicated text utilities** — `normalizeInlineText` and `truncate` are
+   redefined in `persistent-steward.ts` (addressed separately in the state
+   decomposition doc).
+
+4. **Divergent prompt assembly** — `buildStewardTurnPrompt` (steward.ts)
+   and `buildPersistentStewardSystemPrompt` + bootstrap/refresh messages
+   (persistent-steward.ts) encode the same steward identity and
+   instructions in different formats. When one gets updated, the other
+   drifts.
+
+5. **No shared test coverage** — because the context loading is duplicated,
+   there's no way to test "steward context is correct" once and know both
+   paths get it right.
+
+---
+
+## Root Cause
+
+The two files were built at different times for different execution models:
+
+- `steward.ts` was built first for one-shot CLI execution
+- `persistent-steward.ts` was built later for the Pi session model
+
+Each assembled its own context because the persistent steward needed a
+different delivery format (bootstrap + refresh deltas vs single prompt).
+But the *content* of the context is the same. The difference is packaging,
+not substance.
+
+---
+
+## Proposed Solution: Extract `steward-context.ts`
+
+Create a shared layer that both execution modes consume.
+
+### `src/lib/steward-context.ts`
+
+This file owns:
+
+1. **The canonical steward context type**
+2. **Context loading** — one function that loads everything the steward needs
+3. **Shared rendering** — digest/summary rendering used by both modes
+4. **Prompt content blocks** — the reusable content sections that both prompt
+   formats draw from
+
+```typescript
+// The unified context type
+export type StewardContext = {
+  // Identity
+  soul: string;
+  identity: string;
+  selfContext: string;
+  agents: string;
+
+  // Project
+  projectId: string;
+  projectPath: string;
+  boardDigest: string;
+  boardSummary: BoardSummary;
+
+  // Coordination state
+  openMessages: OpenMessagesSummary;
+  activeRuns: ActiveRunsSummary;
+  recentResults: RecentResultsSummary;
+  humanInbox: HumanInboxSummary;
+
+  // Memory
+  memory: PromptMemoryContext;
+
+  // Session
+  recentTurns: SessionTurn[];
+  deltaHistory: DeltaHistoryEntry[];
+  sessionState: SessionState | null;
+
+  // Policy
+  cognitivePolicy: string;
+  skills: string[];
+
+  // Derived
+  revision: number;
+};
+
+// One function to load it all
+export async function loadStewardContext(
+  paths: HivePaths,
+  projectId: string,
+  sessionId?: string,
+): Promise<StewardContext>;
+
+// Shared rendering (currently duplicated in both files)
+export function renderRecentTurns(turns: SessionTurn[], limit?: number): string;
+export function renderDeltaHistory(entries: DeltaHistoryEntry[]): string;
+export function renderRecentResultsDigest(summary: RecentResultsSummary): string;
+export function renderHumanInboxDigest(summary: HumanInboxSummary): string;
+export function loadDeltaHistory(paths: ProjectPaths, since?: number): DeltaHistoryEntry[];
+
+// Reusable prompt content blocks
+export function renderStewardIdentityBlock(ctx: StewardContext): string;
+export function renderStewardStateBlock(ctx: StewardContext): string;
+export function renderStewardInstructionsBlock(ctx: StewardContext): string;
+```
+
+### Refactored `steward.ts`
+
+Becomes thin. Imports `StewardContext` and `loadStewardContext`, then:
+
+1. Loads context
+2. Assembles it into a single one-shot prompt using the content blocks
+3. Launches runtime
+4. Captures result
+
+No context loading logic. No rendering functions. ~200 lines.
+
+### Refactored `persistent-steward.ts`
+
+Imports `StewardContext` and `loadStewardContext`, then:
+
+1. Loads context for bootstrap
+2. Packages content blocks into system prompt + bootstrap message
+3. On refresh, loads only the delta and packages it as a refresh message
+4. Manages the Pi session lifecycle
+
+The Pi process management, streaming, and session lifecycle stay here.
+Context loading and rendering move out. ~800 lines (down from 1,391).
+
+---
+
+## The Refresh Path
+
+The persistent steward has a concept the one-shot steward doesn't: refresh
+turns that send only deltas. This is a real difference, not artificial
+duplication.
+
+`steward-context.ts` should also export:
+
+```typescript
+export type StewardRefreshDelta = {
+  revision: number;
+  changes: StewardDeltaChange[];
+  humanMessage: string | null;
+  workerCompletions: RecentResultSummaryItem[];
+};
+
+export async function loadStewardRefreshDelta(
+  paths: HivePaths,
+  projectId: string,
+  sinceRevision: number,
+): Promise<StewardRefreshDelta>;
+```
+
+The one-shot steward ignores this (it always does a full load). The
+persistent steward uses it for efficient subsequent turns.
+
+---
+
+## Migration Steps
+
+1. **Create `steward-context.ts`** with the unified type and
+   `loadStewardContext`. Initially, this can delegate to existing loading
+   code — just centralize the call sites.
+
+2. **Move shared rendering functions** from both files into
+   `steward-context.ts`. Delete the duplicates.
+
+3. **Refactor `steward.ts`** to import and use `loadStewardContext` +
+   content blocks. Remove its internal context loading.
+
+4. **Refactor `persistent-steward.ts`** to import and use
+   `loadStewardContext` + content blocks. Remove its internal context
+   loading and rendering duplicates.
+
+5. **Extract prompt content blocks** — identify the shared prose
+   (steward identity, instructions, initiative directives) that appears
+   in both prompt builders. Make these shared functions that return
+   markdown strings.
+
+6. **Update tests** — add `steward-context.test.ts` that verifies
+   context loading once. Existing steward tests become thinner.
+
+---
+
+## What Stays Separate
+
+The execution models are genuinely different and should remain in their
+own files:
+
+| Concern                    | `steward.ts`        | `persistent-steward.ts` |
+|---------------------------|---------------------|-------------------------|
+| Session lifecycle          | None (one-shot)     | Pi process management   |
+| Prompt format              | Single combined     | System + bootstrap + refresh |
+| Streaming                  | Runtime adapter     | Pi subscribe events     |
+| Context delivery           | Full every time     | Bootstrap once, then deltas |
+| Run ledger integration     | Direct              | Gateway-managed         |
+
+These are real architectural differences. Don't force them together.
+
+---
+
+## Success Criteria
+
+1. `loadStewardContext` is called from exactly two places: `steward.ts`
+   and `persistent-steward.ts`.
+2. Zero rendering functions are duplicated across files.
+3. Updating the steward's identity prose or instructions happens in one
+   place and affects both execution modes.
+4. `persistent-steward.ts` drops below 900 lines.
+5. `steward.ts` drops below 300 lines.
+6. All existing tests pass unchanged.


### PR DESCRIPTION
## Summary

This PR adds four comprehensive design documents that outline a major refactoring of HIVE's steward and state management systems. These documents establish the architectural vision and migration path for simplifying critical infrastructure.

## Documents Added

- **SIMPLIFY-PERSISTENT-STEWARD.md** — Proposes replacing the subprocess-based persistent steward with an in-process Pi library integration, eliminating ~600 lines of process management code and making the steward genuinely disposable.

- **SIMPLIFY-STEWARD-UNIFICATION.md** — Identifies and proposes consolidating duplicated context loading and rendering logic between `steward.ts` and `persistent-steward.ts` into a shared `steward-context.ts` module.

- **SIMPLIFY-STATE-DECOMPOSITION.md** — Breaks down the monolithic `state.ts` (983 lines) into focused modules: `text.ts`, `board-parse.ts`, `state-delta.ts`, and `state-refresh.ts`, eliminating duplicated parsing logic across the codebase.

- **SIMPLIFY-COMMAND-SURFACE.md** — Consolidates HIVE's 28+ CLI commands into a cleaner 25-command surface by absorbing overlapping commands (`chat` → `console --once`, `nudge` → `msg --type nudge`, `supervise` → `run` subcommands).

## Key Themes

These documents establish:

1. **Elimination of duplication** — Shared context loading, text utilities, and task parsing currently scattered across multiple files
2. **Subprocess elimination** — Moving from Pi CLI subprocess to in-process library usage
3. **Improved testability** — Breaking monolithic modules into focused, independently testable units
4. **Clearer user experience** — Reducing command surface complexity through consolidation

## Implementation Status

These are design documents only. No source code changes are included. They establish the architectural direction and success criteria for future implementation work.

https://claude.ai/code/session_01STVMusRtdboEF8obPx7mmj