### PR TITLE
Add dialectic council mode for multi-round adversarial debate

### DIFF
--- a/docs/BEYOND-ORCHESTRATION.md
+++ b/docs/BEYOND-ORCHESTRATION.md
@@ -1,0 +1,375 @@
+# Beyond Orchestration: What Makes an AI Employee
+
+Research note. March 2026.
+
+---
+
+## The Landscape Ate Orchestration
+
+HIVE v1 built a full orchestration stack: persistent steward, ephemeral
+workers, goal decomposition, OODA loops, file-native state, dream commands,
+supervisors. It was a genuine contribution. Then two things happened:
+
+1. Claude Code shipped delegate mode, worktrees, hooks, and MCP.
+2. OpenClaw shipped session persistence, heartbeats, memory, and compaction.
+
+The orchestration layer became commodity. Not worthless — the specific
+choices HIVE made (file-native, multi-model, coordination separated from
+execution) still have architectural merit. But the *category* is no longer
+empty. Every serious coding agent now has some version of: dispatch work,
+watch it, recover from failures, persist state across sessions.
+
+HIVE v2 recognized this and stripped down to the layers that *weren't*
+commodity: persistent identity, cross-session memory, and multi-model
+council. That was the right call. The question now is what to build on
+top of that foundation.
+
+---
+
+## The Employee Gap
+
+Here's the thing no framework has solved: every AI coding tool today,
+including HIVE, behaves like a contractor, not an employee.
+
+A contractor:
+- receives scoped work
+- executes it competently
+- delivers results
+- forgets everything between engagements
+
+An employee:
+- develops judgment about what matters in this specific context
+- notices things without being asked
+- understands the team, the politics, the preferences
+- owns outcomes across time, not just tasks in the moment
+- has taste — an internal sense of what "good" looks like *here*
+- tracks their own commitments and follows through unprompted
+
+The gap is not intelligence. GPT-4 and Claude are smart enough. The gap
+is *accumulation* — the slow compounding of experience into something
+that looks like judgment, initiative, and contextual wisdom.
+
+OpenClaw gives you session continuity. Claude Code gives you tool
+orchestration. HIVE gives you persistent identity and memory. But none
+of them give you the thing that makes a first-month employee different
+from a twelfth-month employee: the steady transformation of raw
+experience into reliable intuition about *this* codebase, *this* team,
+*this* product.
+
+---
+
+## Five Capabilities That Would Cross the Line
+
+### 1. Judgment Accumulation (not just memory)
+
+Memory stores facts: "the API uses pagination tokens, not offsets."
+Judgment stores heuristics: "when the tests pass but the latency numbers
+look off, dig into the database queries before declaring victory."
+
+The difference is that memory is *what happened* and judgment is *what
+it means for future decisions*. Today's memory systems — HIVE's included
+— store the first kind. Nobody stores the second kind well.
+
+What this looks like concretely:
+
+- After a PR gets requested changes, the system doesn't just remember
+  "reviewer X asked for Y." It extracts: "reviewer X consistently cares
+  about error handling at API boundaries. In the future, pre-check those
+  paths before opening PRs that touch the API layer."
+- After a deploy goes sideways, it doesn't just log the incident. It
+  records: "deploys on Fridays have caused three incidents in this repo.
+  Recommend waiting until Monday unless the change is both small and
+  well-tested."
+- After multiple code reviews, it develops: "this codebase values
+  explicitness over cleverness. Prefer verbose-but-clear over
+  elegant-but-dense."
+
+This is the difference between a knowledge base and a colleague's
+intuition. The knowledge base says "here is what happened." The colleague
+says "here is what I think we should do about it, based on patterns I've
+noticed."
+
+**The implementation shape:** A judgment layer that sits above memory.
+It periodically reviews accumulated facts, decisions, and outcomes, then
+synthesizes heuristic rules. These aren't code — they're natural language
+patterns like "when X, prefer Y because Z (based on incidents A, B, C)."
+They're ranked by confidence (how many supporting observations), recency
+(has anything contradicted this?), and scope (project-specific vs.
+universal). The council is the perfect mechanism for this — multiple
+models reviewing the same evidence and converging on reliable heuristics
+vs. overfit anecdotes.
+
+### 2. Initiative and Noticing
+
+An employee doesn't sit idle between assignments. They notice things.
+
+- "The error rate in the logs has been creeping up for three days."
+- "This dependency hasn't been updated in 14 months and has known CVEs."
+- "The test that covers the payment flow has been skipped for two weeks."
+- "The new feature we shipped last Tuesday has zero usage in production."
+- "The PR from last week is still open with unresolved review comments."
+
+This is qualitatively different from autonomous task execution. It's not
+"do work without being asked." It's "have opinions about what deserves
+attention." The system maintains a background awareness of the project's
+health, momentum, and emerging risks — and surfaces observations at
+appropriate moments rather than dumping them all the time.
+
+**The implementation shape:** A periodic scan that runs against the
+project's state (git log, CI results, issue tracker, dependency manifest,
+production metrics if available). Each scan produces observations ranked
+by severity and novelty. Novel high-severity observations get surfaced
+to the human. Repeated low-severity ones accumulate until they cross a
+threshold. The key design constraint is *taste* — surfacing too much is
+worse than surfacing too little. The system should learn which categories
+of observation the human acts on vs. ignores, and calibrate accordingly.
+
+### 3. Relationship and Context Modeling
+
+An employee understands people, not just code.
+
+- "Alice's code reviews are thorough on architecture, quick on style. If
+  she requests changes, they're worth addressing carefully."
+- "Bob tends to file issues with minimal reproduction steps. If his bug
+  report seems incomplete, ask once — he usually has more context but
+  didn't think to include it."
+- "The team prefers small PRs. Anything over 400 lines gets pushback
+  regardless of content quality."
+- "Carol is the domain expert on the billing system. If you need to
+  understand why the invoice calculation works the way it does, her
+  commits and review comments are the primary source."
+
+This is *social memory* — understanding the human context around the
+technical work. It's what makes the difference between "correct code"
+and "code that will actually get merged by this team."
+
+**The implementation shape:** Entity models in memory. Not full
+psychological profiles — lightweight patterns about interaction style,
+domain expertise, review preferences, and communication norms. Updated
+incrementally from PR reviews, issue discussions, and commit patterns.
+Used to inform how the system approaches work: choosing reviewers,
+anticipating feedback, calibrating PR size and description detail.
+
+### 4. Temporal Awareness and Commitment Tracking
+
+An employee understands time.
+
+- "It's been a week since we said we'd follow up on the performance
+  regression. Should I look into it?"
+- "The quarterly planning meeting is next Thursday. The spike we talked
+  about should probably be finished before then so we have data."
+- "This TODO has been in the codebase for six months. Three people have
+  touched the file since. Either it matters and we should do it, or it
+  doesn't and we should delete it."
+
+This is the follow-through dimension. Today's AI tools are purely
+reactive — they respond to the current turn's input. An employee
+maintains a sense of open loops, aging commitments, and upcoming
+deadlines, and proactively manages them.
+
+**The implementation shape:** A commitments register — promises made
+in conversations, TODOs noted, follow-ups agreed to — with timestamps
+and decay behavior. The system periodically scans the register and
+surfaces items approaching their expected completion date or that have
+gone stale. This is different from a todo list because it's *extracted
+from conversation*, not manually created. When you say "let's revisit
+this after the release," the system notes the commitment and will
+actually revisit it.
+
+### 5. Taste as Learned Preference
+
+An employee develops taste about what "good" looks like in context.
+
+Not style guide compliance — actual aesthetic and quality judgment that
+emerges from immersion in a specific codebase and team. Things like:
+
+- "This codebase uses simple loops over functional chains. The map/filter
+  approach is technically equivalent but doesn't match the grain."
+- "Error messages in this project are user-facing, not developer-facing.
+  'Failed to connect' should be 'Unable to reach the server — check your
+  internet connection and try again.'"
+- "The team strongly prefers composition over inheritance. Even when
+  inheritance looks cleaner in the abstract, the existing patterns
+  suggest they've been burned by deep hierarchies before."
+
+Taste is what makes a senior employee's code review different from a
+junior's. The junior checks correctness. The senior checks *fit* — does
+this change move the codebase in the direction it wants to go?
+
+**The implementation shape:** This is the hardest one to engineer
+explicitly, and maybe the most natural one to emerge from the other
+four. If judgment accumulation captures review patterns, if relationship
+modeling captures team preferences, if memory captures past decisions
+and their rationale — then taste is the synthesis layer over all of
+these. The council is again well-suited here: ask multiple models to
+evaluate a proposed change not just for correctness but for fit, feeding
+them the accumulated judgment and context. Where they agree on fit, you
+have a taste signal. Where they disagree, you have a question worth
+asking the human.
+
+---
+
+## What HIVE Already Has
+
+The surprising thing is that HIVE's v2 foundation — identity, memory,
+council — maps well to these capabilities:
+
+| Capability | HIVE Foundation | Gap |
+|---|---|---|
+| Judgment accumulation | Memory stores facts and decisions | No heuristic synthesis layer |
+| Initiative and noticing | Council can analyze from multiple angles | No periodic scan, no taste calibration |
+| Relationship modeling | Memory is per-project, entity-aware | No explicit people models |
+| Temporal awareness | Decisions are timestamped | No commitments register, no follow-through |
+| Taste | Council produces multi-perspective evaluation | No accumulated preference model |
+
+The foundation is right. The identity layer means the system has a
+persistent self-concept. The memory layer means experience accumulates.
+The council means multiple perspectives inform judgment. What's missing
+is the *active layer* that turns passive storage into proactive behavior.
+
+---
+
+## The Architecture of the Next Layer
+
+If orchestration is "how to dispatch and coordinate work" and identity
+is "who am I and what do I know," the next layer is **cognitive
+accumulation** — the ongoing transformation of experience into judgment.
+
+```
+┌─────────────────────────────────────────┐
+│  Cognitive Accumulation Layer            │
+│                                         │
+│  judgment heuristics                    │
+│  initiative observations                │
+│  relationship models                    │
+│  commitment tracking                    │
+│  taste preferences                      │
+│                                         │
+├─────────────────────────────────────────┤
+│  Identity Layer (HIVE v2)               │
+│                                         │
+│  SOUL / IDENTITY / SELF                 │
+│  project memory                         │
+│  multi-model council                    │
+│                                         │
+├─────────────────────────────────────────┤
+│  Orchestration Layer (Claude Code, etc) │
+│                                         │
+│  tool use, delegation, worktrees        │
+│  session management, hooks, MCP         │
+│  task dispatch, supervision             │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+The orchestration layer is commodity. The identity layer is where HIVE
+already lives. The cognitive accumulation layer is what would make HIVE
+genuinely new.
+
+---
+
+## Why This Matters Beyond HIVE
+
+Every AI company is converging on the same pitch: "AI employees."
+Anthropic says it. OpenAI says it. Google says it. Cognition built
+Devin on the premise. But nobody has crossed the line from "AI that
+does tasks" to "AI that accumulates judgment."
+
+The reason is structural. Session-based tools lose everything between
+sessions. Memory-augmented tools remember facts but don't synthesize
+them. Agent frameworks route work but don't develop opinions about how
+to do it better next time.
+
+The company or project that solves cognitive accumulation — the slow
+compounding of experience into contextual wisdom — will have built
+something qualitatively different from everything else in the market.
+Not a better task executor. Not a better orchestrator. An actual
+colleague.
+
+HIVE is in an interesting position because its architectural bets
+(persistent identity, accumulated memory, multi-perspective council)
+are precisely the foundation this layer needs. The question is whether
+to build it.
+
+---
+
+## Concrete Next Steps (If We Build It)
+
+### Phase 1: Judgment Extraction (smallest useful slice)
+
+Extend the session reflection protocol. Today `reflect_session` records
+facts, conventions, decisions, and questions. Add a fifth type:
+**heuristic** — a pattern derived from experience that should influence
+future behavior.
+
+Format: "When [situation], prefer [action] because [evidence]."
+
+After each session, the system reviews accumulated heuristics for
+consistency, merges compatible ones, and flags contradictions for human
+review. The council validates proposed heuristics: if multiple models
+agree the pattern is well-supported, it gets promoted. If they disagree,
+it stays provisional.
+
+### Phase 2: Commitment Register
+
+Extract commitments from conversations. "Let's revisit this after the
+release" becomes a tracked item with an expected follow-up date. The
+system surfaces stale commitments periodically. This is the simplest
+form of temporal awareness — it doesn't require calendar integration or
+production monitoring, just conversation parsing and a timer.
+
+### Phase 3: Initiative Scans
+
+Periodic background analysis of the project state. Git log velocity,
+PR age distribution, test coverage trends, dependency freshness, TODO
+accumulation. Observations ranked by novelty and severity. The system
+learns which observations the human acts on and calibrates its threshold.
+
+### Phase 4: People Models
+
+Lightweight entity models built from PR reviews, commit patterns, and
+issue discussions. Not personality profiles — functional models: "who
+knows what, who cares about what, who reviews how." Used to inform
+approach when the system is working on code that will be reviewed by
+specific people.
+
+### Phase 5: Taste Synthesis
+
+The integrative layer. Council-based evaluation of proposed changes
+against accumulated judgment, relationship models, and codebase patterns.
+"This code is correct, but it doesn't fit the grain of this project.
+Here's why and here's an alternative that does."
+
+---
+
+## The Hard Question
+
+All of this is technically feasible. The hard question is whether it's
+*desirable*. An AI that accumulates judgment and develops opinions is
+also an AI that can be wrong in persistent, compounding ways. A bad
+heuristic that gets promoted could bias the system's recommendations
+for weeks. A misread relationship model could cause the system to
+optimize for the wrong reviewer's preferences.
+
+The answer is probably the same as with human employees: judgment
+accumulation is valuable *when paired with accountability*. The system
+needs to show its work — "I'm recommending this approach because of
+heuristic H, derived from incidents X, Y, Z." The human needs to be
+able to challenge, correct, and override accumulated judgment. And the
+system needs to update its models when corrected, not defensively
+persist in its prior conclusions.
+
+HIVE's trust ladder and approval queue already point in this direction.
+The cognitive accumulation layer should inherit the same principle:
+**internal boldness with external humility**. Develop opinions freely.
+Surface them confidently. Update them immediately when evidence or the
+human says otherwise.
+
+---
+
+## One Sentence
+
+The next frontier beyond orchestration is **cognitive accumulation**:
+the systematic transformation of an AI's raw experience into the kind
+of contextual judgment, initiative, and taste that distinguishes a
+twelfth-month employee from a first-day contractor.

--- a/docs/IMPLEMENTATION-PLAN-COGNITIVE-LAYER.md
+++ b/docs/IMPLEMENTATION-PLAN-COGNITIVE-LAYER.md
@@ -1,0 +1,557 @@
+# Implementation Plan: Cognitive Accumulation Layer
+
+Three concrete builds that move HIVE from identity/memory/council into
+genuine cognitive accumulation. Each is independently shippable.
+
+---
+
+## Build 1: Heuristic Extraction (Autoresearch Pattern)
+
+### The Idea
+
+Apply Karpathy's [autoresearch](https://github.com/karpathy/autoresearch)
+ratchet pattern to judgment extraction. Autoresearch's core loop is:
+modify → evaluate → keep/revert → repeat, with a single metric (val_bpb)
+as the ratchet. We adapt this for heuristics: propose → validate via
+council → keep/discard → repeat.
+
+The "metric" isn't a loss number — it's council consensus. A heuristic is
+kept if multiple models agree the evidence supports it. Discarded if not.
+
+### What a Heuristic Looks Like
+
+```
+When [situation], prefer [action] because [evidence].
+Confidence: high | medium | low
+Sources: [list of specific observations]
+```
+
+Examples:
+- "When tests pass but latency benchmarks regress, investigate DB queries
+  before declaring the change safe. Confidence: high. Sources: incidents
+  on 2026-03-12, 2026-03-19, PR #47 revert."
+- "When opening PRs that touch the API layer, pre-check error handling at
+  boundaries — reviewer Alice consistently requests this. Confidence:
+  medium. Sources: PR #31, #38, #42 reviews."
+
+### Storage
+
+New file per project: `~/.hive/memory/projects/<project>-heuristics.md`
+
+Separate from the main memory file because:
+1. Heuristics have different lifecycle (confidence, validation, decay)
+2. They need to be loadable independently (injected into session context)
+3. The main memory file is already structured with four sections; bolting
+   on a fundamentally different entry type would compromise it
+
+Structure:
+
+```markdown
+# Heuristics: <project>
+
+## Active
+- [2026-03-30] When [situation], prefer [action] because [evidence]. (confidence: high, sources: 3)
+- [2026-03-29] When [situation], prefer [action] because [evidence]. (confidence: medium, sources: 2)
+
+## Provisional
+- [2026-03-30] When [situation], prefer [action] because [evidence]. (sources: 1, pending validation)
+
+## Retired
+- [2026-03-28] When [situation]... (retired: contradicted by [evidence])
+```
+
+### The Nightly Loop (program.md Pattern)
+
+A `program.md`-style prompt that drives the extraction. This runs as a
+scheduled Claude Code task (or the HIVE `schedule` skill).
+
+**Input context assembled for each iteration:**
+1. Project memory (facts, conventions, decisions)
+2. Existing heuristics (active + provisional)
+3. Recent git log (last 24h of commits, diffs, PR activity)
+4. Recent session reflections
+
+**Each iteration:**
+
+1. **Propose**: The agent scans the input context for recurring patterns,
+   near-misses, post-mortems, review feedback. Proposes 1-3 candidate
+   heuristics in the canonical format.
+
+2. **Validate via council**: Each candidate is sent to `convene_council`
+   with the question: "Given the following evidence, is this heuristic
+   well-supported, specific enough to be actionable, and not redundant
+   with existing heuristics? Evidence: [sources]. Proposed heuristic:
+   [text]. Existing heuristics: [list]."
+
+3. **Keep or discard**: If the council reaches consensus (all models agree
+   it's well-supported), promote to Active. If majority agrees but with
+   caveats, add to Provisional. If no consensus, discard with a note in
+   the iteration log.
+
+4. **Repeat**: Scan for more candidates until the agent runs out of
+   novel patterns or hits a configured iteration cap (default: 10
+   iterations per nightly run).
+
+**The ratchet**: Heuristics only promote if they pass council validation.
+The set monotonically improves in quality (bad heuristics get discarded,
+good ones accumulate). Provisional heuristics get re-validated in future
+runs as more evidence appears.
+
+### Implementation: Files to Create/Modify
+
+**New files:**
+- `src/lib/heuristics.ts` — CRUD for heuristic files (read, append,
+  promote, retire, validate structure). Mirrors `memory.ts` patterns:
+  write queue, structural validation, entry validation.
+- `src/programs/heuristic-extraction.md` — The program.md-style prompt
+  for the nightly job. Human-editable. Defines the loop, the council
+  validation criteria, the keep/discard logic.
+
+**Modified files:**
+- `src/lib/paths.ts` — Add `heuristicsPath(projectId)` helper.
+- `src/mcp-server.ts` — Add `read_hive_heuristics` tool (so the session
+  hook can inject active heuristics into context).
+- `src/cli.ts` + new `src/commands/heuristics.ts` — `hive heuristics
+  view`, `hive heuristics extract` (runs one extraction iteration
+  manually), `hive heuristics validate <id>` (re-validates a provisional
+  heuristic via council).
+- `.claude/hooks/load-identity.sh` — Append active heuristics to session
+  context alongside memory.
+
+### Types
+
+```typescript
+type HeuristicStatus = "active" | "provisional" | "retired";
+
+type Heuristic = {
+  id: string;           // short hash or sequential
+  date: string;         // ISO date
+  situation: string;    // "When..."
+  action: string;       // "prefer..."
+  evidence: string;     // "because..."
+  confidence: "high" | "medium" | "low";
+  sources: string[];    // specific observations
+  status: HeuristicStatus;
+  retiredReason?: string;
+};
+
+type HeuristicExtractionResult = {
+  proposed: Heuristic[];
+  promoted: Heuristic[];
+  discarded: { heuristic: Heuristic; reason: string }[];
+  iterationsRun: number;
+};
+```
+
+### Estimated Scope
+
+~300 lines for `heuristics.ts`, ~50 lines for the CLI command, ~30 lines
+for the MCP tool, ~200 lines for the program.md prompt. Plus tests.
+
+---
+
+## Build 2: Taste Framework
+
+### The Idea
+
+Taste is distinct from memory. Memory says "what happened." Taste says
+"how things should be done here." It's a compact, curated set of
+preferences that the system consults when making or evaluating changes.
+
+A nightly job reviews the day's work (diffs, reviews, conversations)
+against the existing taste structure. It looks for:
+- Entries that need nuance added
+- New patterns not yet captured
+- Entries that are stale or contradicted
+
+### What Taste Entries Look Like
+
+Each entry is brief, specific, and actionable. Not principles — instances.
+
+```
+## Code Style
+- Error messages are user-facing, not developer-facing. "Failed to connect"
+  → "Unable to reach the server — check your internet connection."
+- Simple loops over functional chains. map/filter is technically equivalent
+  but doesn't match the codebase grain.
+- Explicit over clever. Prefer verbose-but-clear over elegant-but-dense.
+
+## Architecture
+- Composition over inheritance. Deep hierarchies have burned the team before.
+- Files over databases for anything that benefits from inspectability.
+- No abstraction until the third instance. Three similar lines > premature helper.
+
+## Review Norms
+- PRs over 400 lines get pushback regardless of quality. Split them.
+- Always explain *why* in the PR description, not just *what*.
+
+## Naming
+- Boolean variables: is/has/should prefix. No bare adjectives.
+- Config keys: kebab-case. Never snake_case or camelCase.
+```
+
+### Storage
+
+New file per project: `~/.hive/memory/projects/<project>-taste.md`
+
+This file is designed to be **compact and always-loaded**. It doesn't grow
+unboundedly like memory. Target: under 100 entries, each 1-2 lines. If it
+gets larger, the nightly job should consolidate redundant entries.
+
+Structure:
+
+```markdown
+# Taste: <project>
+
+## Code Style
+(entries)
+
+## Architecture
+(entries)
+
+## Review Norms
+(entries)
+
+## Naming
+(entries)
+
+## Error Handling
+(entries)
+
+## Testing
+(entries)
+```
+
+Categories are not fixed — the nightly job can propose new categories if
+a cluster of entries doesn't fit existing ones. But it should merge before
+creating, to resist sprawl.
+
+### The Nightly Job
+
+**Input context:**
+1. Current taste file
+2. Day's git diffs (commits in last 24h)
+3. Day's PR review comments (if available via MCP)
+4. Day's session reflections
+5. Day's new memory entries
+
+**The job does three things:**
+
+1. **Evaluate existing entries**: For each taste entry, check if today's
+   work confirms it, contradicts it, or suggests a refinement. Flag
+   contradictions for human review. Apply refinements directly.
+
+2. **Propose new entries**: Scan the day's work for patterns not yet
+   captured. A new taste entry must be:
+   - Specific (not "write good code")
+   - Evidenced (at least 2 instances in recent work)
+   - Distinct from existing entries (not a restatement)
+
+3. **Consolidate**: If the file has grown past the target size, merge
+   redundant entries and remove stale ones.
+
+**Unlike heuristics, taste doesn't use the council for validation.**
+Taste is about pattern recognition in the existing codebase, not
+multi-perspective analysis. A single model reviewing diffs against the
+taste file is sufficient. The council is for contested questions; taste
+is for observed patterns.
+
+### Implementation: Files to Create/Modify
+
+**New files:**
+- `src/lib/taste.ts` — Read/write/update taste files. Structured by
+  category. Entry-level operations (add, refine, remove, move between
+  categories).
+- `src/programs/taste-review.md` — The nightly review prompt.
+
+**Modified files:**
+- `src/lib/paths.ts` — Add `tastePath(projectId)` helper.
+- `src/mcp-server.ts` — Add `read_hive_taste` tool.
+- `src/cli.ts` + new `src/commands/taste.ts` — `hive taste view`,
+  `hive taste review` (manual trigger).
+- `.claude/hooks/load-identity.sh` — Append taste to session context.
+
+### Why Taste is Separate from Memory
+
+Memory is append-only and unbounded. Each entry is independent. The
+question is "what do we know?"
+
+Taste is curated and bounded. Entries relate to each other (an
+architecture taste entry might contextualize a code style entry). The
+question is "what do we prefer?" Taste entries get *refined* over time,
+not just accumulated. A memory fact from March is still a fact in June.
+A taste entry from March might be refined three times by June as the
+team's preferences evolve.
+
+The nightly review job is what makes this distinction operational. Memory
+gets appended. Taste gets *maintained*.
+
+### Estimated Scope
+
+~200 lines for `taste.ts`, ~40 lines for CLI, ~25 lines for MCP tool,
+~150 lines for the review prompt. Plus tests.
+
+---
+
+## Build 3: Dialectic Council
+
+### The Idea
+
+The current council mode is **convergent**: all models get the same prompt,
+give independent analysis, the chair synthesizes agreement/disagreement.
+This is good for questions with a likely right answer.
+
+The dialectic mode is **divergent**: models are assigned specific positions
+("camps") and must argue them as strongly as possible. The goal is not
+consensus but *stress-testing* — finding the strongest version of each
+argument so the chair can make an informed judgment.
+
+This is adversarial by design. Not hostile — rigorous. Each model is told:
+"Your job is to make the strongest possible case for position X. Find
+every supporting argument. Anticipate and preempt counterarguments.
+Concede only what you must."
+
+### When to Use Which Mode
+
+| Mode | Use When |
+|---|---|
+| Standard council | You want independent analysis. "What's the best approach?" |
+| Analyst council | You want structured analytical thinking. "What are the risks?" |
+| Dialectic council | You want stress-tested arguments. "Should we rewrite or refactor?" |
+
+The dialectic mode is specifically valuable when:
+- The question has 2-3 genuinely defensible positions
+- The team is leaning one way and wants the counterargument pressure-tested
+- A decision is high-stakes and irreversible
+- You suspect confirmation bias in the existing analysis
+
+### How It Works
+
+**Input:**
+```typescript
+type DialecticInput = {
+  question: string;
+  camps: Camp[];       // 2-4 positions to argue
+  context?: string;    // shared background
+};
+
+type Camp = {
+  name: string;        // "rewrite", "refactor", "hybrid"
+  position: string;    // 1-2 sentence summary of the position
+  brief?: string;      // optional additional context for this camp
+};
+```
+
+**Assignment:** Models are assigned to camps round-robin. If there are
+3 models and 2 camps, two models argue one side and one argues the other.
+If there are 4 models and 3 camps, one model argues each camp and the
+fourth acts as a **skeptic** (assigned to poke holes in all positions
+without advocating for any).
+
+**System prompt per camp:**
+
+```
+You are arguing for the following position in a structured dialectic:
+
+Position: [camp.position]
+
+Your job is to make the STRONGEST possible case for this position.
+This is not about balance — it is about rigor. Find every supporting
+argument. Anticipate counterarguments and preempt them. Concede points
+only when denial would undermine your credibility.
+
+You are not performing a character. You are doing the intellectual work
+of finding the best version of this argument. If the position has genuine
+weaknesses, acknowledge them briefly and explain why the position is
+still the best option despite them.
+
+The question: [question]
+Context: [context]
+```
+
+**Skeptic prompt (if extra model):**
+
+```
+You are the skeptic in a structured dialectic. Your job is to find the
+weakest points in ALL positions being argued. You do not advocate for
+any position. You pressure-test each one.
+
+For each position, identify:
+- The strongest counterargument they haven't addressed
+- The assumption most likely to be wrong
+- The failure mode they're underweighting
+
+The question: [question]
+Context: [context]
+Positions being argued: [list of camps]
+```
+
+**Chair synthesis prompt (different from standard council):**
+
+```
+You just chaired a dialectic. Models argued assigned positions as
+strongly as possible. Synthesize:
+
+**Strongest argument from each camp:** What was the single most
+compelling point each side made?
+
+**Exposed weaknesses:** Where did a position fail to hold up under
+its own advocacy? (If even the model arguing FOR it had to concede
+significant ground, that's signal.)
+
+**Emerged insights:** What new considerations surfaced that weren't
+in the original framing?
+
+**Your judgment:** Given the strongest versions of all arguments,
+what do you actually recommend — and why?
+
+Do not split the difference. Take a position.
+```
+
+### Implementation: Files to Create/Modify
+
+**Modified files:**
+
+`src/lib/council.ts`:
+- Add `Camp` and `DialecticInput` types
+- Add `buildDialecticMemberPrompt(camp: Camp)` — generates the
+  camp-specific system prompt
+- Add `buildSkepticPrompt(camps: Camp[])` — generates the skeptic prompt
+- Add `assignCamps(members: CouncilMember[], camps: Camp[])` — returns
+  `Array<{ member: CouncilMember, camp: Camp | "skeptic" }>`
+- Add `conveneDialectic(input: DialecticInput & { members, globalConfig })`
+  — parallel dispatch like `conveneCouncil` but with per-member prompts
+- Add `formatDialecticResultsForSteward(result)` — different synthesis
+  prompt than standard council
+
+`src/mcp-server.ts`:
+- Extend `convene_council` tool with optional `mode` parameter:
+  `"standard" | "analyst" | "dialectic"`
+- When `mode === "dialectic"`, require `camps` parameter (array of
+  `{ name, position, brief? }`)
+- Route to `conveneDialectic` instead of `conveneCouncil`
+
+`src/commands/council.ts`:
+- Add `--mode dialectic` flag
+- Add `--camps` flag (JSON string or interactive)
+- Example: `hive council --mode dialectic --camps '[{"name":"rewrite","position":"Full rewrite of the auth system"},{"name":"refactor","position":"Incremental refactoring over 3 sprints"}]' "Should we rewrite or refactor the auth system?"`
+
+### Types
+
+```typescript
+type Camp = {
+  name: string;
+  position: string;
+  brief?: string;
+};
+
+type DialecticAssignment = {
+  member: CouncilMember;
+  role: "advocate" | "skeptic";
+  camp?: Camp;  // present when role === "advocate"
+};
+
+type DialecticPosition = CouncilPosition & {
+  role: "advocate" | "skeptic";
+  campName?: string;
+};
+
+type DialecticResult = {
+  question: string;
+  camps: Camp[];
+  positions: DialecticPosition[];
+  durationMs: number;
+};
+```
+
+### Estimated Scope
+
+~150 lines added to `council.ts`, ~40 lines added to MCP server,
+~30 lines added to CLI command. Plus tests for prompt generation,
+camp assignment, and formatting.
+
+---
+
+## Build Order
+
+**Build 3 first (Dialectic Council).** Smallest scope, modifies existing
+code, immediately useful, validates the council extension pattern. Can
+ship in one session. Also needed by Build 1 (heuristic validation uses
+standard council, but dialectic mode would strengthen validation for
+contested heuristics).
+
+**Build 2 second (Taste Framework).** Creates the new file structure and
+nightly review pattern. Independent of the council — taste review uses
+a single model, not the council. Establishes the "curated artifact that
+gets maintained, not just appended" pattern that distinguishes taste
+from memory.
+
+**Build 1 third (Heuristic Extraction).** The most complex. Depends on
+council working well (Build 3), benefits from taste being established
+(Build 2 — some heuristics are taste-adjacent and should be routed to
+taste instead). The autoresearch-style loop is the most novel thing here
+and will need iteration to get the prompts right.
+
+---
+
+## Nightly Job Infrastructure
+
+Both Build 1 and Build 2 need a way to run as nightly scheduled jobs.
+Two options:
+
+**Option A: Claude Code `schedule` skill.** Use the existing `/schedule`
+skill to create cron-triggered remote agents. The program.md prompts
+become the agent instructions. This is zero new infrastructure — it
+rides Claude Code's scheduling.
+
+**Option B: `hive dream`-style command.** Add `hive extract` and
+`hive taste-review` commands that can be run manually or via system
+cron / launchd. These would invoke the council and write results
+directly, without needing a full Claude Code session.
+
+**Recommendation: Option A for v1.** It's simpler, uses existing
+infrastructure, and keeps HIVE focused on being a Claude Code
+integration layer rather than a standalone daemon. If scheduling
+proves unreliable, fall back to Option B.
+
+---
+
+## What This Does NOT Do
+
+- No production monitoring integration (yet). Initiative/noticing from
+  the research doc is deferred — it requires external data sources that
+  vary per project.
+- No relationship modeling (yet). People models need PR review data at
+  scale, which means tighter GitHub integration than we have today.
+- No commitment tracking (yet). Requires conversation parsing that's
+  hard to do well outside the session that generated the conversation.
+- No automatic taste or heuristic injection into code generation. These
+  artifacts inform the *human and steward's judgment*, not the model's
+  system prompt (yet). That's a later integration.
+
+---
+
+## Success Criteria
+
+### Dialectic Council
+1. `hive council --mode dialectic` works from CLI
+2. `convene_council` MCP tool accepts `mode: "dialectic"` with camps
+3. Models argue assigned positions, not independent analysis
+4. Chair synthesis identifies strongest arguments and takes a position
+5. Skeptic role assigned when models > camps
+
+### Taste Framework
+1. `~/.hive/memory/projects/<project>-taste.md` exists and is loadable
+2. Taste is injected into session context via hook
+3. `hive taste view` shows current taste
+4. Nightly review prompt can add, refine, and consolidate entries
+5. File stays under 100 entries after multiple review cycles
+
+### Heuristic Extraction
+1. `~/.hive/memory/projects/<project>-heuristics.md` exists with
+   active/provisional/retired sections
+2. Extraction loop proposes, validates via council, keeps or discards
+3. Heuristics are injected into session context via hook
+4. `hive heuristics view` shows active heuristics
+5. At least 3 genuine heuristics extracted after first nightly run on
+   a project with >2 weeks of history

--- a/docs/IMPLEMENTATION-PLAN-COGNITIVE-LAYER.md
+++ b/docs/IMPLEMENTATION-PLAN-COGNITIVE-LAYER.md
@@ -3,438 +3,154 @@
 Three concrete builds that move HIVE from identity/memory/council into
 genuine cognitive accumulation. Each is independently shippable.
 
----
-
-## Build 1: Heuristic Extraction (Autoresearch Pattern)
-
-### The Idea
-
-Apply Karpathy's [autoresearch](https://github.com/karpathy/autoresearch)
-ratchet pattern to judgment extraction. Autoresearch's core loop is:
-modify → evaluate → keep/revert → repeat, with a single metric (val_bpb)
-as the ratchet. We adapt this for heuristics: propose → validate via
-council → keep/discard → repeat.
-
-The "metric" isn't a loss number — it's council consensus. A heuristic is
-kept if multiple models agree the evidence supports it. Discarded if not.
-
-### What a Heuristic Looks Like
-
-```
-When [situation], prefer [action] because [evidence].
-Confidence: high | medium | low
-Sources: [list of specific observations]
-```
-
-Examples:
-- "When tests pass but latency benchmarks regress, investigate DB queries
-  before declaring the change safe. Confidence: high. Sources: incidents
-  on 2026-03-12, 2026-03-19, PR #47 revert."
-- "When opening PRs that touch the API layer, pre-check error handling at
-  boundaries — reviewer Alice consistently requests this. Confidence:
-  medium. Sources: PR #31, #38, #42 reviews."
-
-### Storage
-
-New file per project: `~/.hive/memory/projects/<project>-heuristics.md`
-
-Separate from the main memory file because:
-1. Heuristics have different lifecycle (confidence, validation, decay)
-2. They need to be loadable independently (injected into session context)
-3. The main memory file is already structured with four sections; bolting
-   on a fundamentally different entry type would compromise it
-
-Structure:
-
-```markdown
-# Heuristics: <project>
-
-## Active
-- [2026-03-30] When [situation], prefer [action] because [evidence]. (confidence: high, sources: 3)
-- [2026-03-29] When [situation], prefer [action] because [evidence]. (confidence: medium, sources: 2)
-
-## Provisional
-- [2026-03-30] When [situation], prefer [action] because [evidence]. (sources: 1, pending validation)
-
-## Retired
-- [2026-03-28] When [situation]... (retired: contradicted by [evidence])
-```
-
-### The Nightly Loop (program.md Pattern)
-
-A `program.md`-style prompt that drives the extraction. This runs as a
-scheduled Claude Code task (or the HIVE `schedule` skill).
-
-**Input context assembled for each iteration:**
-1. Project memory (facts, conventions, decisions)
-2. Existing heuristics (active + provisional)
-3. Recent git log (last 24h of commits, diffs, PR activity)
-4. Recent session reflections
-
-**Each iteration:**
-
-1. **Propose**: The agent scans the input context for recurring patterns,
-   near-misses, post-mortems, review feedback. Proposes 1-3 candidate
-   heuristics in the canonical format.
-
-2. **Validate via council**: Each candidate is sent to `convene_council`
-   with the question: "Given the following evidence, is this heuristic
-   well-supported, specific enough to be actionable, and not redundant
-   with existing heuristics? Evidence: [sources]. Proposed heuristic:
-   [text]. Existing heuristics: [list]."
-
-3. **Keep or discard**: If the council reaches consensus (all models agree
-   it's well-supported), promote to Active. If majority agrees but with
-   caveats, add to Provisional. If no consensus, discard with a note in
-   the iteration log.
-
-4. **Repeat**: Scan for more candidates until the agent runs out of
-   novel patterns or hits a configured iteration cap (default: 10
-   iterations per nightly run).
-
-**The ratchet**: Heuristics only promote if they pass council validation.
-The set monotonically improves in quality (bad heuristics get discarded,
-good ones accumulate). Provisional heuristics get re-validated in future
-runs as more evidence appears.
-
-### Implementation: Files to Create/Modify
-
-**New files:**
-- `src/lib/heuristics.ts` — CRUD for heuristic files (read, append,
-  promote, retire, validate structure). Mirrors `memory.ts` patterns:
-  write queue, structural validation, entry validation.
-- `src/programs/heuristic-extraction.md` — The program.md-style prompt
-  for the nightly job. Human-editable. Defines the loop, the council
-  validation criteria, the keep/discard logic.
-
-**Modified files:**
-- `src/lib/paths.ts` — Add `heuristicsPath(projectId)` helper.
-- `src/mcp-server.ts` — Add `read_hive_heuristics` tool (so the session
-  hook can inject active heuristics into context).
-- `src/cli.ts` + new `src/commands/heuristics.ts` — `hive heuristics
-  view`, `hive heuristics extract` (runs one extraction iteration
-  manually), `hive heuristics validate <id>` (re-validates a provisional
-  heuristic via council).
-- `.claude/hooks/load-identity.sh` — Append active heuristics to session
-  context alongside memory.
-
-### Types
-
-```typescript
-type HeuristicStatus = "active" | "provisional" | "retired";
-
-type Heuristic = {
-  id: string;           // short hash or sequential
-  date: string;         // ISO date
-  situation: string;    // "When..."
-  action: string;       // "prefer..."
-  evidence: string;     // "because..."
-  confidence: "high" | "medium" | "low";
-  sources: string[];    // specific observations
-  status: HeuristicStatus;
-  retiredReason?: string;
-};
-
-type HeuristicExtractionResult = {
-  proposed: Heuristic[];
-  promoted: Heuristic[];
-  discarded: { heuristic: Heuristic; reason: string }[];
-  iterationsRun: number;
-};
-```
-
-### Estimated Scope
-
-~300 lines for `heuristics.ts`, ~50 lines for the CLI command, ~30 lines
-for the MCP tool, ~200 lines for the program.md prompt. Plus tests.
+Nightly job infrastructure is built separately — not in scope here.
 
 ---
 
-## Build 2: Taste Framework
+## Build 1: Dialectic Council (multi-round adversarial)
 
 ### The Idea
 
-Taste is distinct from memory. Memory says "what happened." Taste says
-"how things should be done here." It's a compact, curated set of
-preferences that the system consults when making or evaluating changes.
+The existing council is convergent: same prompt, independent analysis,
+chair synthesizes. The dialectic is divergent: models are assigned camps,
+argue positions as strongly as possible, and — critically — **see each
+other's arguments and refine across multiple rounds**.
 
-A nightly job reviews the day's work (diffs, reviews, conversations)
-against the existing taste structure. It looks for:
-- Entries that need nuance added
-- New patterns not yet captured
-- Entries that are stale or contradicted
+This is a real dialectic, not parallel one-shots. Each round, every model
+receives what the others argued and gets to sharpen, concede, or pivot.
 
-### What Taste Entries Look Like
+### Round Structure
 
-Each entry is brief, specific, and actionable. Not principles — instances.
+**Round 1**: Each model argues its assigned camp position. No visibility
+into other models' arguments. Pure independent advocacy.
 
-```
-## Code Style
-- Error messages are user-facing, not developer-facing. "Failed to connect"
-  → "Unable to reach the server — check your internet connection."
-- Simple loops over functional chains. map/filter is technically equivalent
-  but doesn't match the codebase grain.
-- Explicit over clever. Prefer verbose-but-clear over elegant-but-dense.
+**Round 2**: Each model receives ALL other models' Round 1 responses.
+Prompt: "Here is what the other side argued. Refine your position.
+Address their strongest points. Concede where you must. Sharpen where
+you can."
 
-## Architecture
-- Composition over inheritance. Deep hierarchies have burned the team before.
-- Files over databases for anything that benefits from inspectability.
-- No abstraction until the third instance. Three similar lines > premature helper.
+**Round 3** (default final): Each model receives ALL Round 2 responses.
+Prompt: "This is the final round. Make your strongest case, incorporating
+everything you've learned from the debate. Where has your position
+genuinely improved? Where has the other side made points you can't
+dismiss?"
 
-## Review Norms
-- PRs over 400 lines get pushback regardless of quality. Split them.
-- Always explain *why* in the PR description, not just *what*.
+Rounds are configurable (default 3, min 1, max 5). Round 1 is parallel
+across models. Rounds 2+ are parallel within each round but sequential
+between rounds.
 
-## Naming
-- Boolean variables: is/has/should prefix. No bare adjectives.
-- Config keys: kebab-case. Never snake_case or camelCase.
-```
+### Camp Assignment
 
-### Storage
+Models are assigned to camps round-robin. If models > camps, extras
+become **skeptics** — they poke holes in all positions without
+advocating for any. Skeptics participate in all rounds with visibility
+into all arguments.
 
-New file per project: `~/.hive/memory/projects/<project>-taste.md`
+### System Prompts
 
-This file is designed to be **compact and always-loaded**. It doesn't grow
-unboundedly like memory. Target: under 100 entries, each 1-2 lines. If it
-gets larger, the nightly job should consolidate redundant entries.
-
-Structure:
-
-```markdown
-# Taste: <project>
-
-## Code Style
-(entries)
-
-## Architecture
-(entries)
-
-## Review Norms
-(entries)
-
-## Naming
-(entries)
-
-## Error Handling
-(entries)
-
-## Testing
-(entries)
-```
-
-Categories are not fixed — the nightly job can propose new categories if
-a cluster of entries doesn't fit existing ones. But it should merge before
-creating, to resist sprawl.
-
-### The Nightly Job
-
-**Input context:**
-1. Current taste file
-2. Day's git diffs (commits in last 24h)
-3. Day's PR review comments (if available via MCP)
-4. Day's session reflections
-5. Day's new memory entries
-
-**The job does three things:**
-
-1. **Evaluate existing entries**: For each taste entry, check if today's
-   work confirms it, contradicts it, or suggests a refinement. Flag
-   contradictions for human review. Apply refinements directly.
-
-2. **Propose new entries**: Scan the day's work for patterns not yet
-   captured. A new taste entry must be:
-   - Specific (not "write good code")
-   - Evidenced (at least 2 instances in recent work)
-   - Distinct from existing entries (not a restatement)
-
-3. **Consolidate**: If the file has grown past the target size, merge
-   redundant entries and remove stale ones.
-
-**Unlike heuristics, taste doesn't use the council for validation.**
-Taste is about pattern recognition in the existing codebase, not
-multi-perspective analysis. A single model reviewing diffs against the
-taste file is sufficient. The council is for contested questions; taste
-is for observed patterns.
-
-### Implementation: Files to Create/Modify
-
-**New files:**
-- `src/lib/taste.ts` — Read/write/update taste files. Structured by
-  category. Entry-level operations (add, refine, remove, move between
-  categories).
-- `src/programs/taste-review.md` — The nightly review prompt.
-
-**Modified files:**
-- `src/lib/paths.ts` — Add `tastePath(projectId)` helper.
-- `src/mcp-server.ts` — Add `read_hive_taste` tool.
-- `src/cli.ts` + new `src/commands/taste.ts` — `hive taste view`,
-  `hive taste review` (manual trigger).
-- `.claude/hooks/load-identity.sh` — Append taste to session context.
-
-### Why Taste is Separate from Memory
-
-Memory is append-only and unbounded. Each entry is independent. The
-question is "what do we know?"
-
-Taste is curated and bounded. Entries relate to each other (an
-architecture taste entry might contextualize a code style entry). The
-question is "what do we prefer?" Taste entries get *refined* over time,
-not just accumulated. A memory fact from March is still a fact in June.
-A taste entry from March might be refined three times by June as the
-team's preferences evolve.
-
-The nightly review job is what makes this distinction operational. Memory
-gets appended. Taste gets *maintained*.
-
-### Estimated Scope
-
-~200 lines for `taste.ts`, ~40 lines for CLI, ~25 lines for MCP tool,
-~150 lines for the review prompt. Plus tests.
-
----
-
-## Build 3: Dialectic Council
-
-### The Idea
-
-The current council mode is **convergent**: all models get the same prompt,
-give independent analysis, the chair synthesizes agreement/disagreement.
-This is good for questions with a likely right answer.
-
-The dialectic mode is **divergent**: models are assigned specific positions
-("camps") and must argue them as strongly as possible. The goal is not
-consensus but *stress-testing* — finding the strongest version of each
-argument so the chair can make an informed judgment.
-
-This is adversarial by design. Not hostile — rigorous. Each model is told:
-"Your job is to make the strongest possible case for position X. Find
-every supporting argument. Anticipate and preempt counterarguments.
-Concede only what you must."
-
-### When to Use Which Mode
-
-| Mode | Use When |
-|---|---|
-| Standard council | You want independent analysis. "What's the best approach?" |
-| Analyst council | You want structured analytical thinking. "What are the risks?" |
-| Dialectic council | You want stress-tested arguments. "Should we rewrite or refactor?" |
-
-The dialectic mode is specifically valuable when:
-- The question has 2-3 genuinely defensible positions
-- The team is leaning one way and wants the counterargument pressure-tested
-- A decision is high-stakes and irreversible
-- You suspect confirmation bias in the existing analysis
-
-### How It Works
-
-**Input:**
-```typescript
-type DialecticInput = {
-  question: string;
-  camps: Camp[];       // 2-4 positions to argue
-  context?: string;    // shared background
-};
-
-type Camp = {
-  name: string;        // "rewrite", "refactor", "hybrid"
-  position: string;    // 1-2 sentence summary of the position
-  brief?: string;      // optional additional context for this camp
-};
-```
-
-**Assignment:** Models are assigned to camps round-robin. If there are
-3 models and 2 camps, two models argue one side and one argues the other.
-If there are 4 models and 3 camps, one model argues each camp and the
-fourth acts as a **skeptic** (assigned to poke holes in all positions
-without advocating for any).
-
-**System prompt per camp:**
-
+**Round 1 (advocate):**
 ```
 You are arguing for the following position in a structured dialectic:
 
-Position: [camp.position]
+Position: {camp.position}
 
-Your job is to make the STRONGEST possible case for this position.
-This is not about balance — it is about rigor. Find every supporting
-argument. Anticipate counterarguments and preempt them. Concede points
-only when denial would undermine your credibility.
+Make the STRONGEST possible case. This is not about balance — it is
+about rigor. Find every supporting argument. Anticipate
+counterarguments and preempt them.
 
-You are not performing a character. You are doing the intellectual work
-of finding the best version of this argument. If the position has genuine
-weaknesses, acknowledge them briefly and explain why the position is
-still the best option despite them.
+You are not performing a character. You are doing the intellectual
+work of finding the best version of this argument.
 
-The question: [question]
-Context: [context]
+The question: {question}
+Context: {context}
 ```
 
-**Skeptic prompt (if extra model):**
-
+**Round 2+ (advocate):**
 ```
-You are the skeptic in a structured dialectic. Your job is to find the
-weakest points in ALL positions being argued. You do not advocate for
-any position. You pressure-test each one.
+You are in round {n} of a dialectic arguing for: {camp.position}
+
+Here is what was argued in the previous round:
+
+{formatted previous round positions}
+
+Refine your position. Address the strongest points made against you.
+Concede where denial would undermine your credibility. Sharpen where
+the other side was weak.
+
+Do not repeat your previous arguments verbatim. Evolve them.
+```
+
+**Round 1 (skeptic):**
+```
+You are the skeptic in a structured dialectic. You do not advocate
+for any position. You pressure-test each one.
 
 For each position, identify:
 - The strongest counterargument they haven't addressed
 - The assumption most likely to be wrong
 - The failure mode they're underweighting
 
-The question: [question]
-Context: [context]
-Positions being argued: [list of camps]
+The question: {question}
+Context: {context}
+Positions being argued: {list of camps}
 ```
 
-**Chair synthesis prompt (different from standard council):**
-
+**Round 2+ (skeptic):**
 ```
-You just chaired a dialectic. Models argued assigned positions as
-strongly as possible. Synthesize:
+You are the skeptic in round {n}. Here is what was argued:
 
-**Strongest argument from each camp:** What was the single most
-compelling point each side made?
+{formatted previous round positions}
 
-**Exposed weaknesses:** Where did a position fail to hold up under
-its own advocacy? (If even the model arguing FOR it had to concede
-significant ground, that's signal.)
+Update your analysis. Which positions got stronger? Which got weaker?
+What are they still not addressing?
+```
 
-**Emerged insights:** What new considerations surfaced that weren't
-in the original framing?
+**Chair synthesis (after all rounds):**
+```
+You chaired a {rounds}-round dialectic. Synthesize:
 
-**Your judgment:** Given the strongest versions of all arguments,
-what do you actually recommend — and why?
+**Evolution:** How did positions change across rounds? What was
+conceded? What hardened?
+
+**Strongest surviving argument from each camp:** After multiple
+rounds of pressure, what still stands?
+
+**Exposed weaknesses:** Where did a position fail to hold up even
+with its own advocate refining it across rounds?
+
+**Emerged insights:** What surfaced that wasn't in the original
+framing?
+
+**Your judgment:** Given the strongest battle-tested versions of all
+arguments, what do you recommend — and why?
 
 Do not split the difference. Take a position.
 ```
 
-### Implementation: Files to Create/Modify
+### Implementation
 
 **Modified files:**
 
 `src/lib/council.ts`:
-- Add `Camp` and `DialecticInput` types
-- Add `buildDialecticMemberPrompt(camp: Camp)` — generates the
-  camp-specific system prompt
-- Add `buildSkepticPrompt(camps: Camp[])` — generates the skeptic prompt
-- Add `assignCamps(members: CouncilMember[], camps: Camp[])` — returns
-  `Array<{ member: CouncilMember, camp: Camp | "skeptic" }>`
-- Add `conveneDialectic(input: DialecticInput & { members, globalConfig })`
-  — parallel dispatch like `conveneCouncil` but with per-member prompts
-- Add `formatDialecticResultsForSteward(result)` — different synthesis
-  prompt than standard council
+- New types: `Camp`, `DialecticInput`, `DialecticAssignment`,
+  `DialecticRound`, `DialecticResult`
+- `assignCamps(members, camps)` → assignment array
+- `buildDialecticPrompt(assignment, round, previousRounds)` → per-member
+  per-round system prompt
+- `conveneDialectic(input)` → sequential rounds, parallel within each
+  round. Returns all rounds' positions plus timing.
+- `formatDialecticResultsForSteward(result)` → chair synthesis prompt
+  with full round history
 
 `src/mcp-server.ts`:
-- Extend `convene_council` tool with optional `mode` parameter:
-  `"standard" | "analyst" | "dialectic"`
-- When `mode === "dialectic"`, require `camps` parameter (array of
-  `{ name, position, brief? }`)
-- Route to `conveneDialectic` instead of `conveneCouncil`
+- Extend `convene_council` with `mode: "standard" | "analyst" | "dialectic"`
+- When dialectic: require `camps` array, accept optional `rounds` (default 3)
+- Route to `conveneDialectic`
 
 `src/commands/council.ts`:
-- Add `--mode dialectic` flag
-- Add `--camps` flag (JSON string or interactive)
-- Example: `hive council --mode dialectic --camps '[{"name":"rewrite","position":"Full rewrite of the auth system"},{"name":"refactor","position":"Incremental refactoring over 3 sprints"}]' "Should we rewrite or refactor the auth system?"`
+- `--mode dialectic` flag
+- `--camps` flag (JSON array)
+- `--rounds` flag (default 3)
 
 ### Types
 
@@ -448,110 +164,290 @@ type Camp = {
 type DialecticAssignment = {
   member: CouncilMember;
   role: "advocate" | "skeptic";
-  camp?: Camp;  // present when role === "advocate"
+  camp?: Camp;
+};
+
+type DialecticRound = {
+  roundNumber: number;
+  positions: DialecticPosition[];
+  durationMs: number;
 };
 
 type DialecticPosition = CouncilPosition & {
   role: "advocate" | "skeptic";
   campName?: string;
+  roundNumber: number;
 };
 
 type DialecticResult = {
   question: string;
   camps: Camp[];
-  positions: DialecticPosition[];
-  durationMs: number;
+  rounds: DialecticRound[];
+  totalDurationMs: number;
 };
 ```
 
 ### Estimated Scope
 
-~150 lines added to `council.ts`, ~40 lines added to MCP server,
-~30 lines added to CLI command. Plus tests for prompt generation,
-camp assignment, and formatting.
+~250 lines in council.ts, ~50 in MCP server, ~40 in CLI. Plus tests.
+
+---
+
+## Build 2: Taste Framework
+
+### The Idea
+
+Taste is distinct from memory. Memory says "what happened." Taste says
+"how things should be done here." It's a compact, curated set of
+preferences — not principles, instances.
+
+**Critical refinement:** Taste needs a clear heuristic for what taste
+*means*, and that heuristic is discovered through conversation with the
+user, not automated analysis. Some taste is easily stated ("we prefer
+composition over inheritance"). Some requires interactive refinement
+("why did you reject that PR approach? what was wrong with it exactly?").
+
+### Discovery Protocol
+
+Taste starts as a **structured conversation**, not a batch job. The
+system needs an interactive discovery mode:
+
+1. **Seed questions**: The system asks the user targeted questions to
+   surface taste. Not open-ended — structured around categories:
+   - "When you review code, what makes you request changes vs. approve?"
+   - "Show me a PR you thought was well-done. What made it good?"
+   - "Show me a PR that frustrated you. What was wrong?"
+   - "What architectural patterns do you reach for? What do you avoid?"
+   - "When two approaches are both correct, what makes you prefer one?"
+
+2. **Propose and react**: The system analyzes codebase patterns and
+   proposes taste entries. The user confirms, refines, or rejects.
+   - "I notice the codebase avoids class hierarchies. Is that intentional?"
+   - "Error messages seem to be user-facing throughout. Is that a rule?"
+   - "PRs in this repo average 150 lines. Is small-PR preference explicit?"
+
+3. **Refine over time**: As work happens, the system occasionally asks
+   "does this still match your taste?" or proposes refinements based on
+   observed drift.
+
+This discovery process IS the product for taste. The nightly review job
+(if any) is secondary — it evaluates the day's work against established
+taste, but it can't *discover* taste without the human in the loop.
+
+### What Taste Entries Look Like
+
+Brief, specific, actionable. Not principles — instances.
+
+```markdown
+# Taste: <project>
+
+## Code Style
+- Error messages are user-facing. "Failed to connect" →
+  "Unable to reach the server — check your internet connection."
+- Simple loops over functional chains. map/filter doesn't match the grain.
+- Explicit over clever. Verbose-but-clear beats elegant-but-dense.
+
+## Architecture
+- Composition over inheritance. Always.
+- Files over databases for anything that benefits from inspectability.
+- No abstraction until the third instance.
+
+## Review Norms
+- PRs under 400 lines. Split anything larger.
+- PR description explains *why*, not just *what*.
+
+## Naming
+- Boolean variables: is/has/should prefix.
+- Config keys: kebab-case.
+```
+
+### Storage
+
+`~/.hive/memory/projects/<project>-taste.md`
+
+Designed to be compact and always-loaded. Target: under 100 entries,
+each 1-2 lines. Categories are not fixed but should resist sprawl — merge
+before creating new categories.
+
+### Why Separate from Memory
+
+Memory is append-only and unbounded. Taste is **maintained** — entries
+get refined, consolidated, and retired. A memory fact from March is still
+a fact in June. A taste entry from March might be refined three times by
+June as preferences evolve.
+
+### Implementation
+
+**New files:**
+- `src/lib/taste.ts` — Read/write/update taste files. Category-based
+  structure. Entry operations: add, refine, remove, move between
+  categories.
+- `src/programs/taste-discovery.md` — Prompt template for the interactive
+  discovery session.
+
+**Modified files:**
+- `src/lib/paths.ts` — Add `tastePath(projectId)` helper.
+- `src/mcp-server.ts` — Add `read_hive_taste` tool.
+- `src/cli.ts` + new `src/commands/taste.ts` — `hive taste view`,
+  `hive taste discover` (interactive session).
+- `.claude/hooks/load-identity.sh` — Append taste to session context.
+
+### Estimated Scope
+
+~200 lines for taste.ts, ~40 for CLI, ~25 for MCP tool, ~200 for
+discovery prompt. Plus tests.
+
+---
+
+## Build 3: Heuristic Extraction (Autoresearch Ratchet)
+
+### The Idea
+
+Apply Karpathy's autoresearch pattern to judgment extraction. The key
+insight: autoresearch works because it has a **precise, mechanical
+metric** — val_bpb goes up or down. Council consensus is NOT the right
+metric. It's vibes, not measurement.
+
+The hard problem: **what is the number?**
+
+### Finding the Metric
+
+A heuristic is: "When [situation], prefer [action] because [evidence]."
+
+The testable claim is: *in past instances of [situation], did [action]
+correlate with better outcomes?*
+
+**Candidate metric: historical hit rate.**
+
+For a proposed heuristic, the extraction loop:
+
+1. Identifies all historical instances of [situation] in the project's
+   git history, PR history, and memory.
+2. For each instance, checks: was [action] taken?
+3. For each instance, checks: what was the outcome? (PR merged cleanly?
+   Reverted? Required follow-up fixes? Review requested changes?)
+4. Computes: hit rate = (instances where action taken AND good outcome)
+   / (total instances of situation).
+
+A heuristic with hit rate > threshold (e.g. 0.7) is promoted. Below
+threshold, discarded. Insufficient instances (< 3), stays provisional.
+
+**Example:**
+- Proposed: "When touching the API layer, pre-check error handling at
+  boundaries."
+- Scan: 12 PRs touched the API layer in the last 3 months.
+- 8 of them included error handling changes → 5 merged cleanly, 3
+  required minor revisions.
+- 4 of them did NOT include error handling → 1 merged cleanly, 3 got
+  review comments specifically about error handling.
+- Hit rate: error handling present correlates with clean merge 62% vs
+  25%. Signal is strong. Promote.
+
+This is genuinely mechanical. The number goes up or down.
+
+### The Ratchet Loop
+
+Like autoresearch: propose → test → keep/revert → repeat.
+
+**Each iteration:**
+
+1. **Propose**: Agent scans recent memory, git log, PR activity for
+   a recurring pattern. Formulates a candidate heuristic.
+
+2. **Test**: Query historical data for instances of the situation.
+   Compute hit rate. This is the equivalent of running train.py and
+   checking val_bpb.
+
+3. **Keep or revert**: If hit rate > threshold and instances >= minimum,
+   promote to Active. If hit rate <= threshold, discard. If insufficient
+   instances, mark Provisional.
+
+4. **Repeat**: Continue until iteration cap or no more novel candidates.
+
+**The ratchet**: Heuristics only enter Active if the number clears the
+bar. The active set monotonically improves in evidence quality.
+
+### What Needs to Be True
+
+This approach requires structured access to project history:
+- Git log with file-level diffs (available via `git log`)
+- PR review data (available if GitHub MCP is configured)
+- Existing memory entries (available)
+
+The extraction agent needs to be able to query these programmatically,
+not just read raw text. This might mean a small set of helper functions
+for the program.md to call:
+- `findCommitsTouching(pathPattern, dateRange)` → commit list
+- `findPRsWithReviewComments(dateRange)` → PR list with outcomes
+- `findRevertedCommits(dateRange)` → commits that were later reverted
+
+### Storage
+
+Same as before: `~/.hive/memory/projects/<project>-heuristics.md`
+with Active / Provisional / Retired sections. Each entry includes
+hit rate and instance count.
+
+```markdown
+## Active
+- [2026-03-30] When touching API layer, pre-check error handling at
+  boundaries. (hit-rate: 0.72, instances: 12, sources: PR #31-#47)
+
+## Provisional
+- [2026-03-30] When modifying test fixtures, run the full suite not
+  just related tests. (instances: 2, pending: need 3+)
+
+## Retired
+- [2026-03-28] When... (retired: hit-rate dropped to 0.4 after 8 new
+  instances)
+```
+
+### Open Questions
+
+- **Is hit rate the right metric, or is there a better one?** Hit rate
+  measures correlation, not causation. A heuristic could have high hit
+  rate because good developers do it naturally, not because it causes
+  good outcomes. But correlation is still useful for prediction.
+
+- **How do we define "good outcome" mechanically?** PR merged without
+  revision requests? No revert within 7 days? No related bug filed?
+  Need to pick one or two signals and commit.
+
+- **What's the minimum history needed?** A project with 2 weeks of
+  history might not have enough instances for any heuristic to clear
+  the bar. Need a minimum project age or activity level.
+
+This build needs the most design iteration. The program.md prompt and
+the historical query helpers are the hard parts. The storage and
+lifecycle management are straightforward.
+
+### Estimated Scope
+
+~300 lines for heuristics.ts (storage + lifecycle), ~200 lines for
+historical query helpers, ~50 for CLI, ~30 for MCP tool, ~250 for
+program.md. Plus tests. Most complex of the three builds.
 
 ---
 
 ## Build Order
 
-**Build 3 first (Dialectic Council).** Smallest scope, modifies existing
-code, immediately useful, validates the council extension pattern. Can
-ship in one session. Also needed by Build 1 (heuristic validation uses
-standard council, but dialectic mode would strengthen validation for
-contested heuristics).
+**Build 1 first (Dialectic Council).** Clearest spec, extends existing
+code, immediately useful. Ships in one session.
 
-**Build 2 second (Taste Framework).** Creates the new file structure and
-nightly review pattern. Independent of the council — taste review uses
-a single model, not the council. Establishes the "curated artifact that
-gets maintained, not just appended" pattern that distinguishes taste
-from memory.
+**Build 2 second (Taste Framework).** New file structure, interactive
+discovery protocol. Depends on having a working council for the chair
+to use during taste discovery sessions.
 
-**Build 1 third (Heuristic Extraction).** The most complex. Depends on
-council working well (Build 3), benefits from taste being established
-(Build 2 — some heuristics are taste-adjacent and should be routed to
-taste instead). The autoresearch-style loop is the most novel thing here
-and will need iteration to get the prompts right.
-
----
-
-## Nightly Job Infrastructure
-
-Both Build 1 and Build 2 need a way to run as nightly scheduled jobs.
-Two options:
-
-**Option A: Claude Code `schedule` skill.** Use the existing `/schedule`
-skill to create cron-triggered remote agents. The program.md prompts
-become the agent instructions. This is zero new infrastructure — it
-rides Claude Code's scheduling.
-
-**Option B: `hive dream`-style command.** Add `hive extract` and
-`hive taste-review` commands that can be run manually or via system
-cron / launchd. These would invoke the council and write results
-directly, without needing a full Claude Code session.
-
-**Recommendation: Option A for v1.** It's simpler, uses existing
-infrastructure, and keeps HIVE focused on being a Claude Code
-integration layer rather than a standalone daemon. If scheduling
-proves unreliable, fall back to Option B.
+**Build 3 third (Heuristic Extraction).** Most complex, needs design
+iteration on the metric. Benefits from taste being established (some
+heuristics are taste-adjacent and should route to taste instead).
 
 ---
 
 ## What This Does NOT Do
 
-- No production monitoring integration (yet). Initiative/noticing from
-  the research doc is deferred — it requires external data sources that
-  vary per project.
-- No relationship modeling (yet). People models need PR review data at
-  scale, which means tighter GitHub integration than we have today.
-- No commitment tracking (yet). Requires conversation parsing that's
-  hard to do well outside the session that generated the conversation.
-- No automatic taste or heuristic injection into code generation. These
-  artifacts inform the *human and steward's judgment*, not the model's
-  system prompt (yet). That's a later integration.
-
----
-
-## Success Criteria
-
-### Dialectic Council
-1. `hive council --mode dialectic` works from CLI
-2. `convene_council` MCP tool accepts `mode: "dialectic"` with camps
-3. Models argue assigned positions, not independent analysis
-4. Chair synthesis identifies strongest arguments and takes a position
-5. Skeptic role assigned when models > camps
-
-### Taste Framework
-1. `~/.hive/memory/projects/<project>-taste.md` exists and is loadable
-2. Taste is injected into session context via hook
-3. `hive taste view` shows current taste
-4. Nightly review prompt can add, refine, and consolidate entries
-5. File stays under 100 entries after multiple review cycles
-
-### Heuristic Extraction
-1. `~/.hive/memory/projects/<project>-heuristics.md` exists with
-   active/provisional/retired sections
-2. Extraction loop proposes, validates via council, keeps or discards
-3. Heuristics are injected into session context via hook
-4. `hive heuristics view` shows active heuristics
-5. At least 3 genuine heuristics extracted after first nightly run on
-   a project with >2 weeks of history
+- No nightly job infrastructure (built separately)
+- No production monitoring integration
+- No relationship modeling (needs more GitHub integration)
+- No commitment tracking (needs conversation parsing)
+- No automatic injection into code generation prompts (these artifacts
+  inform human/steward judgment, not model system prompts — yet)

--- a/src/__tests__/council.test.ts
+++ b/src/__tests__/council.test.ts
@@ -4,7 +4,15 @@ import {
   resolveCouncilMembers,
   buildCouncilMemberPrompt,
   formatCouncilResultsForSteward,
+  assignCamps,
+  buildDialecticPrompt,
+  formatDialecticResultsForSteward,
+  clampRounds,
   type CouncilResult,
+  type CouncilMember,
+  type Camp,
+  type DialecticRound,
+  type DialecticResult,
 } from "../lib/council";
 
 const testConfig = `# Test Config
@@ -136,6 +144,345 @@ describe("formatCouncilResultsForSteward", () => {
       ],
     };
     const output = formatCouncilResultsForSteward(withError);
+    expect(output).toContain("**Error:** API timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialectic: clampRounds
+// ---------------------------------------------------------------------------
+
+describe("clampRounds", () => {
+  test("defaults to 3", () => {
+    expect(clampRounds(undefined)).toBe(3);
+    expect(clampRounds(null)).toBe(3);
+  });
+
+  test("clamps to min 1", () => {
+    expect(clampRounds(0)).toBe(1);
+    expect(clampRounds(-5)).toBe(1);
+  });
+
+  test("clamps to max 5", () => {
+    expect(clampRounds(10)).toBe(5);
+    expect(clampRounds(6)).toBe(5);
+  });
+
+  test("passes through valid values", () => {
+    expect(clampRounds(1)).toBe(1);
+    expect(clampRounds(2)).toBe(2);
+    expect(clampRounds(4)).toBe(4);
+    expect(clampRounds(5)).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialectic: assignCamps
+// ---------------------------------------------------------------------------
+
+describe("assignCamps", () => {
+  const makeMember = (name: string): CouncilMember => ({
+    model: { name, runtime: "claude", model: `model-${name}`, description: "" },
+    provider: "anthropic",
+    modelId: `model-${name}`,
+  });
+
+  const camps: Camp[] = [
+    { name: "rewrite", position: "Full rewrite of the auth system" },
+    { name: "refactor", position: "Incremental refactoring over 3 sprints" },
+  ];
+
+  test("assigns camps round-robin with equal members and camps", () => {
+    const members = [makeMember("a"), makeMember("b")];
+    const assignments = assignCamps(members, camps);
+
+    expect(assignments.length).toBe(2);
+    expect(assignments[0]!.role).toBe("advocate");
+    expect(assignments[0]!.camp!.name).toBe("rewrite");
+    expect(assignments[1]!.role).toBe("advocate");
+    expect(assignments[1]!.camp!.name).toBe("refactor");
+  });
+
+  test("first extra member becomes skeptic", () => {
+    const members = [makeMember("a"), makeMember("b"), makeMember("c")];
+    const assignments = assignCamps(members, camps);
+
+    expect(assignments.length).toBe(3);
+    expect(assignments[0]!.role).toBe("advocate");
+    expect(assignments[1]!.role).toBe("advocate");
+    expect(assignments[2]!.role).toBe("skeptic");
+    expect(assignments[2]!.camp).toBeUndefined();
+  });
+
+  test("further extras round-robin back to camps", () => {
+    const members = [makeMember("a"), makeMember("b"), makeMember("c"), makeMember("d")];
+    const assignments = assignCamps(members, camps);
+
+    expect(assignments.length).toBe(4);
+    expect(assignments[2]!.role).toBe("skeptic");
+    expect(assignments[3]!.role).toBe("advocate");
+    expect(assignments[3]!.camp!.name).toBe("rewrite"); // round-robin back
+  });
+
+  test("handles 3 camps with 3 members — no skeptic", () => {
+    const threeCamps: Camp[] = [
+      { name: "a", position: "pos a" },
+      { name: "b", position: "pos b" },
+      { name: "c", position: "pos c" },
+    ];
+    const members = [makeMember("m1"), makeMember("m2"), makeMember("m3")];
+    const assignments = assignCamps(members, threeCamps);
+
+    expect(assignments.length).toBe(3);
+    expect(assignments.every((a) => a.role === "advocate")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialectic: buildDialecticPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildDialecticPrompt", () => {
+  const makeMember = (name: string): CouncilMember => ({
+    model: { name, runtime: "claude", model: `model-${name}`, description: "" },
+    provider: "anthropic",
+    modelId: `model-${name}`,
+  });
+
+  const camps: Camp[] = [
+    { name: "rewrite", position: "Full rewrite" },
+    { name: "refactor", position: "Incremental refactor" },
+  ];
+
+  test("round 1 advocate prompt argues for position", () => {
+    const assignment = { member: makeMember("a"), role: "advocate" as const, camp: camps[0] };
+    const prompt = buildDialecticPrompt(assignment, 1, [], camps);
+
+    expect(prompt).toContain("Full rewrite");
+    expect(prompt).toContain("STRONGEST possible case");
+    expect(prompt).not.toContain("previous round");
+  });
+
+  test("round 1 advocate prompt includes brief when present", () => {
+    const campWithBrief = { ...camps[0]!, brief: "The current auth code is 5 years old" };
+    const assignment = { member: makeMember("a"), role: "advocate" as const, camp: campWithBrief };
+    const prompt = buildDialecticPrompt(assignment, 1, [], camps);
+
+    expect(prompt).toContain("5 years old");
+  });
+
+  test("round 1 skeptic prompt references all camps", () => {
+    const assignment = { member: makeMember("c"), role: "skeptic" as const };
+    const prompt = buildDialecticPrompt(assignment, 1, [], camps);
+
+    expect(prompt).toContain("skeptic");
+    expect(prompt).toContain("rewrite");
+    expect(prompt).toContain("refactor");
+    expect(prompt).toContain("pressure-test");
+  });
+
+  test("round 2+ advocate prompt includes previous round content", () => {
+    const prevRound: DialecticRound = {
+      roundNumber: 1,
+      durationMs: 1000,
+      positions: [
+        {
+          modelName: "a", modelId: "model-a", provider: "anthropic",
+          text: "Rewriting is better because the code is legacy.",
+          inputTokens: null, outputTokens: null, durationMs: 500, error: null,
+          role: "advocate", campName: "rewrite", roundNumber: 1,
+        },
+        {
+          modelName: "b", modelId: "model-b", provider: "anthropic",
+          text: "Refactoring preserves working knowledge.",
+          inputTokens: null, outputTokens: null, durationMs: 500, error: null,
+          role: "advocate", campName: "refactor", roundNumber: 1,
+        },
+      ],
+    };
+
+    const assignment = { member: makeMember("a"), role: "advocate" as const, camp: camps[0] };
+    const prompt = buildDialecticPrompt(assignment, 2, [prevRound], camps);
+
+    expect(prompt).toContain("round 2");
+    expect(prompt).toContain("previous round");
+    expect(prompt).toContain("Rewriting is better");
+    expect(prompt).toContain("Refactoring preserves");
+    expect(prompt).toContain("Refine your position");
+  });
+
+  test("final round prompt says 'final round'", () => {
+    const prevRounds: DialecticRound[] = [
+      { roundNumber: 1, durationMs: 1000, positions: [] },
+      { roundNumber: 2, durationMs: 1000, positions: [] },
+    ];
+
+    const assignment = { member: makeMember("a"), role: "advocate" as const, camp: camps[0] };
+    const prompt = buildDialecticPrompt(assignment, 3, prevRounds, camps);
+
+    expect(prompt).toContain("final round");
+  });
+
+  test("round 2 (non-final) prompt says 'Evolve'", () => {
+    const prevRounds: DialecticRound[] = [
+      { roundNumber: 1, durationMs: 1000, positions: [] },
+    ];
+
+    const assignment = { member: makeMember("a"), role: "advocate" as const, camp: camps[0] };
+    // Round 2 of a 4-round dialectic — not final
+    const prompt = buildDialecticPrompt(assignment, 2, prevRounds, camps);
+
+    expect(prompt).toContain("Evolve");
+    expect(prompt).not.toContain("final round");
+  });
+
+  test("round 2 skeptic prompt references previous arguments", () => {
+    const prevRound: DialecticRound = {
+      roundNumber: 1,
+      durationMs: 1000,
+      positions: [
+        {
+          modelName: "a", modelId: "model-a", provider: "anthropic",
+          text: "Rewriting gives us a clean slate.",
+          inputTokens: null, outputTokens: null, durationMs: 500, error: null,
+          role: "advocate", campName: "rewrite", roundNumber: 1,
+        },
+      ],
+    };
+
+    const assignment = { member: makeMember("c"), role: "skeptic" as const };
+    const prompt = buildDialecticPrompt(assignment, 2, [prevRound], camps);
+
+    expect(prompt).toContain("round 2");
+    expect(prompt).toContain("clean slate");
+    expect(prompt).toContain("Which positions got stronger");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialectic: formatDialecticResultsForSteward
+// ---------------------------------------------------------------------------
+
+describe("formatDialecticResultsForSteward", () => {
+  const mockResult: DialecticResult = {
+    question: "Rewrite vs refactor?",
+    camps: [
+      { name: "rewrite", position: "Full rewrite" },
+      { name: "refactor", position: "Incremental refactor" },
+    ],
+    rounds: [
+      {
+        roundNumber: 1,
+        durationMs: 3000,
+        positions: [
+          {
+            modelName: "opus", modelId: "claude-opus-4-6", provider: "anthropic",
+            text: "Rewriting is the right call because the code is unmaintainable.",
+            inputTokens: 200, outputTokens: 100, durationMs: 1500, error: null,
+            role: "advocate", campName: "rewrite", roundNumber: 1,
+          },
+          {
+            modelName: "sonnet", modelId: "claude-sonnet-4-6", provider: "anthropic",
+            text: "Refactoring preserves institutional knowledge in the code.",
+            inputTokens: 200, outputTokens: 80, durationMs: 1200, error: null,
+            role: "advocate", campName: "refactor", roundNumber: 1,
+          },
+        ],
+      },
+      {
+        roundNumber: 2,
+        durationMs: 3500,
+        positions: [
+          {
+            modelName: "opus", modelId: "claude-opus-4-6", provider: "anthropic",
+            text: "The refactor argument about knowledge preservation is valid but overrated.",
+            inputTokens: 400, outputTokens: 120, durationMs: 1800, error: null,
+            role: "advocate", campName: "rewrite", roundNumber: 2,
+          },
+          {
+            modelName: "sonnet", modelId: "claude-sonnet-4-6", provider: "anthropic",
+            text: "The rewrite advocate concedes the code is hard to work with. But risk is underweighted.",
+            inputTokens: 400, outputTokens: 100, durationMs: 1500, error: null,
+            role: "advocate", campName: "refactor", roundNumber: 2,
+          },
+        ],
+      },
+    ],
+    totalDurationMs: 6500,
+  };
+
+  test("includes question and camps", () => {
+    const output = formatDialecticResultsForSteward(mockResult);
+    expect(output).toContain("Rewrite vs refactor?");
+    expect(output).toContain("rewrite");
+    expect(output).toContain("refactor");
+    expect(output).toContain("vs.");
+  });
+
+  test("shows round structure", () => {
+    const output = formatDialecticResultsForSteward(mockResult);
+    expect(output).toContain("### Round 1");
+    expect(output).toContain("### Round 2");
+  });
+
+  test("labels advocates with camp names", () => {
+    const output = formatDialecticResultsForSteward(mockResult);
+    expect(output).toContain("[ADVOCATE: rewrite]");
+    expect(output).toContain("[ADVOCATE: refactor]");
+  });
+
+  test("includes dialectic-specific synthesis prompt", () => {
+    const output = formatDialecticResultsForSteward(mockResult);
+    expect(output).toContain("**Evolution:**");
+    expect(output).toContain("**Strongest surviving argument");
+    expect(output).toContain("**Exposed weaknesses:**");
+    expect(output).toContain("**Emerged insights:**");
+    expect(output).toContain("Take a position");
+  });
+
+  test("handles skeptic in output", () => {
+    const withSkeptic: DialecticResult = {
+      ...mockResult,
+      rounds: [{
+        roundNumber: 1,
+        durationMs: 2000,
+        positions: [
+          ...mockResult.rounds[0]!.positions,
+          {
+            modelName: "gpt54", modelId: "gpt-5.4", provider: "openai",
+            text: "Both sides underweight migration cost.",
+            inputTokens: 200, outputTokens: 60, durationMs: 1000, error: null,
+            role: "skeptic", campName: undefined, roundNumber: 1,
+          },
+        ],
+      }],
+    };
+
+    const output = formatDialecticResultsForSteward(withSkeptic);
+    expect(output).toContain("[SKEPTIC]");
+    expect(output).toContain("migration cost");
+  });
+
+  test("shows total timing", () => {
+    const output = formatDialecticResultsForSteward(mockResult);
+    expect(output).toContain("6.5s");
+  });
+
+  test("handles error positions", () => {
+    const withError: DialecticResult = {
+      ...mockResult,
+      rounds: [{
+        roundNumber: 1,
+        durationMs: 1000,
+        positions: [{
+          modelName: "opus", modelId: "claude-opus-4-6", provider: "anthropic",
+          text: "", inputTokens: null, outputTokens: null, durationMs: 0, error: "API timeout",
+          role: "advocate", campName: "rewrite", roundNumber: 1,
+        }],
+      }],
+    };
+
+    const output = formatDialecticResultsForSteward(withError);
     expect(output).toContain("**Error:** API timeout");
   });
 });

--- a/src/commands/council.ts
+++ b/src/commands/council.ts
@@ -3,16 +3,33 @@ import { UsageError } from "../lib/errors";
 import { ensureHiveScaffold } from "../lib/paths";
 import {
   conveneCouncil,
+  conveneDialectic,
   formatCouncilResultsForSteward,
+  formatDialecticResultsForSteward,
   resolveCouncilMembers,
+  clampRounds,
+  type Camp,
 } from "../lib/council";
 import { parseModelPool } from "../lib/project";
 
 export async function councilCommand(args: string[]): Promise<void> {
-  const usage = 'Usage: hive council [--models opus,sonnet,gpt54] [--persona analyst] [--format json] "<question>"';
+  const usage = [
+    'Usage: hive council [options] "<question>"',
+    "",
+    "Options:",
+    "  --models opus,sonnet,gpt54   Models to consult (default: all)",
+    "  --persona analyst             Analytical framing (standard mode)",
+    "  --mode dialectic              Adversarial multi-round debate",
+    '  --camps \'[{"name":"..","position":".."},..]\'  Camps for dialectic (JSON)',
+    "  --rounds 3                    Dialectic rounds (1-5, default 3)",
+    "  --format json                 Machine-readable output",
+  ].join("\n");
 
   let modelNames: string[] | null = null;
   let persona: string | null = null;
+  let mode: "standard" | "analyst" | "dialectic" = "standard";
+  let campsJson: string | null = null;
+  let rounds: number | null = null;
   let format: "markdown" | "json" = "markdown";
   const positional: string[] = [];
 
@@ -28,6 +45,23 @@ export async function councilCommand(args: string[]): Promise<void> {
       persona = args[++i] ?? null;
       continue;
     }
+    if (arg === "--mode") {
+      const value = args[++i];
+      if (value === "dialectic") mode = "dialectic";
+      else if (value === "analyst") mode = "analyst";
+      else if (value === "standard") mode = "standard";
+      else throw new UsageError(`Unknown mode '${value}'. Use standard, analyst, or dialectic.\n${usage}`);
+      continue;
+    }
+    if (arg === "--camps") {
+      campsJson = args[++i] ?? null;
+      continue;
+    }
+    if (arg === "--rounds") {
+      const value = args[++i];
+      if (value) rounds = parseInt(value, 10);
+      continue;
+    }
     if (arg === "--format") {
       const value = args[++i];
       if (value === "json") format = "json";
@@ -38,6 +72,20 @@ export async function councilCommand(args: string[]): Promise<void> {
 
   const question = positional.join(" ").trim();
   if (!question) throw new UsageError(`No question provided\n${usage}`);
+
+  // Parse camps for dialectic mode
+  let camps: Camp[] | null = null;
+  if (mode === "dialectic") {
+    if (!campsJson) throw new UsageError(`Dialectic mode requires --camps\n${usage}`);
+    try {
+      camps = JSON.parse(campsJson) as Camp[];
+    } catch {
+      throw new UsageError(`Invalid --camps JSON: ${campsJson}\n${usage}`);
+    }
+    if (!Array.isArray(camps) || camps.length < 2) {
+      throw new UsageError(`Dialectic mode requires at least 2 camps.\n${usage}`);
+    }
+  }
 
   const paths = await ensureHiveScaffold();
   const globalConfig = await Bun.file(paths.config).text().catch(() => "");
@@ -56,6 +104,40 @@ export async function councilCommand(args: string[]): Promise<void> {
     );
   }
 
+  // Dialectic mode
+  if (mode === "dialectic" && camps) {
+    const numRounds = clampRounds(rounds);
+    console.log(`Convening dialectic with ${members.length} members, ${camps.length} camps, ${numRounds} rounds`);
+    console.log(`Camps: ${camps.map((c) => `${c.name} ("${c.position}")`).join(" vs. ")}`);
+    console.log();
+
+    const result = await conveneDialectic({
+      question,
+      camps,
+      members,
+      globalConfig,
+      rounds: numRounds,
+    });
+
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    const output = formatDialecticResultsForSteward(result);
+    console.log(output);
+
+    const allPositions = result.rounds.flatMap((r) => r.positions);
+    const failed = allPositions.filter((p) => p.error);
+    if (failed.length > 0) {
+      console.log();
+      console.log(`Failed: ${failed.map((p) => `${p.modelName} (round ${p.roundNumber}): ${p.error}`).join("; ")}`);
+    }
+    return;
+  }
+
+  // Standard / analyst mode
+  const resolvedPersona = mode === "analyst" ? "analyst" : persona;
   console.log(`Convening council with ${members.length} members: ${members.map((m) => m.model.name).join(", ")}`);
   console.log();
 
@@ -63,7 +145,7 @@ export async function councilCommand(args: string[]): Promise<void> {
     question,
     members,
     globalConfig,
-    persona,
+    persona: resolvedPersona,
   });
 
   if (format === "json") {

--- a/src/lib/council.ts
+++ b/src/lib/council.ts
@@ -42,6 +42,41 @@ export type CouncilResult = {
 };
 
 // ---------------------------------------------------------------------------
+// Dialectic types
+// ---------------------------------------------------------------------------
+
+export type Camp = {
+  name: string;
+  position: string;
+  brief?: string;
+};
+
+export type DialecticAssignment = {
+  member: CouncilMember;
+  role: "advocate" | "skeptic";
+  camp?: Camp;
+};
+
+export type DialecticPosition = CouncilPosition & {
+  role: "advocate" | "skeptic";
+  campName?: string;
+  roundNumber: number;
+};
+
+export type DialecticRound = {
+  roundNumber: number;
+  positions: DialecticPosition[];
+  durationMs: number;
+};
+
+export type DialecticResult = {
+  question: string;
+  camps: Camp[];
+  rounds: DialecticRound[];
+  totalDurationMs: number;
+};
+
+// ---------------------------------------------------------------------------
 // Ollama direct call (for local models not in pi-ai)
 // ---------------------------------------------------------------------------
 
@@ -270,6 +305,125 @@ export function buildCouncilMemberPrompt(persona: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
+// Dialectic: camp assignment
+// ---------------------------------------------------------------------------
+
+export function assignCamps(
+  members: CouncilMember[],
+  camps: Camp[],
+): DialecticAssignment[] {
+  const assignments: DialecticAssignment[] = [];
+
+  for (let i = 0; i < members.length; i++) {
+    if (i < camps.length) {
+      // First N members get one camp each
+      assignments.push({ member: members[i]!, role: "advocate", camp: camps[i]! });
+    } else if (camps.length > 0 && members.length > camps.length) {
+      // Extra members beyond camp count: first extra becomes skeptic,
+      // rest round-robin back to camps
+      const extraIndex = i - camps.length;
+      if (extraIndex === 0) {
+        assignments.push({ member: members[i]!, role: "skeptic" });
+      } else {
+        const campIndex = (extraIndex - 1) % camps.length;
+        assignments.push({ member: members[i]!, role: "advocate", camp: camps[campIndex]! });
+      }
+    }
+  }
+
+  return assignments;
+}
+
+// ---------------------------------------------------------------------------
+// Dialectic: prompt generation
+// ---------------------------------------------------------------------------
+
+function formatPreviousRoundPositions(positions: DialecticPosition[]): string {
+  const lines: string[] = [];
+
+  for (const pos of positions) {
+    if (pos.error) continue;
+    const label = pos.role === "skeptic"
+      ? `${pos.modelName} (skeptic)`
+      : `${pos.modelName} (arguing for: ${pos.campName})`;
+    lines.push(`### ${label}`);
+    lines.push(pos.text);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function buildDialecticPrompt(
+  assignment: DialecticAssignment,
+  roundNumber: number,
+  previousRounds: DialecticRound[],
+  camps: Camp[],
+): string {
+  const prevPositions = previousRounds.length > 0
+    ? previousRounds[previousRounds.length - 1]!.positions
+    : [];
+  const prevFormatted = formatPreviousRoundPositions(prevPositions);
+
+  if (assignment.role === "skeptic") {
+    if (roundNumber === 1) {
+      return [
+        "You are the skeptic in a structured dialectic. You do not advocate for any position. You pressure-test each one.",
+        "",
+        "For each position being argued, identify:",
+        "- The strongest counterargument they haven't addressed",
+        "- The assumption most likely to be wrong",
+        "- The failure mode they're underweighting",
+        "",
+        `Positions being argued: ${camps.map((c) => `"${c.name}" — ${c.position}`).join("; ")}`,
+      ].join("\n");
+    }
+
+    return [
+      `You are the skeptic in round ${roundNumber} of a structured dialectic.`,
+      "",
+      "Here is what was argued in the previous round:",
+      "",
+      prevFormatted,
+      "Update your analysis. Which positions got stronger? Which got weaker? What are they still not addressing?",
+    ].join("\n");
+  }
+
+  // Advocate
+  const camp = assignment.camp!;
+
+  if (roundNumber === 1) {
+    return [
+      "You are arguing for the following position in a structured dialectic:",
+      "",
+      `Position: ${camp.position}`,
+      camp.brief ? `\nContext for your position: ${camp.brief}` : "",
+      "",
+      "Make the STRONGEST possible case. This is not about balance — it is about rigor.",
+      "Find every supporting argument. Anticipate counterarguments and preempt them.",
+      "",
+      "You are not performing a character. You are doing the intellectual work of finding",
+      "the best version of this argument. If the position has genuine weaknesses,",
+      "acknowledge them briefly and explain why the position is still the best option despite them.",
+    ].join("\n");
+  }
+
+  return [
+    `You are in round ${roundNumber} of a dialectic arguing for: ${camp.position}`,
+    "",
+    "Here is what was argued in the previous round:",
+    "",
+    prevFormatted,
+    "Refine your position. Address the strongest points made against you.",
+    "Concede where denial would undermine your credibility. Sharpen where the other side was weak.",
+    "",
+    roundNumber >= 3
+      ? "This is the final round. Make your strongest case, incorporating everything you've learned from the debate. Where has your position genuinely improved? Where has the other side made points you can't dismiss?"
+      : "Do not repeat your previous arguments verbatim. Evolve them.",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point: convene the council
 // ---------------------------------------------------------------------------
 
@@ -294,6 +448,138 @@ export async function conveneCouncil(input: {
     positions: results,
     durationMs: Date.now() - startedAt,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point: convene a dialectic
+// ---------------------------------------------------------------------------
+
+const DEFAULT_DIALECTIC_ROUNDS = 3;
+const MIN_DIALECTIC_ROUNDS = 1;
+const MAX_DIALECTIC_ROUNDS = 5;
+
+export function clampRounds(rounds: number | undefined | null): number {
+  const n = rounds ?? DEFAULT_DIALECTIC_ROUNDS;
+  return Math.max(MIN_DIALECTIC_ROUNDS, Math.min(MAX_DIALECTIC_ROUNDS, n));
+}
+
+export async function conveneDialectic(input: {
+  question: string;
+  camps: Camp[];
+  members: CouncilMember[];
+  globalConfig: string;
+  rounds?: number;
+}): Promise<DialecticResult> {
+  const totalStart = Date.now();
+  const numRounds = clampRounds(input.rounds);
+  const assignments = assignCamps(input.members, input.camps);
+  const completedRounds: DialecticRound[] = [];
+
+  for (let round = 1; round <= numRounds; round++) {
+    const roundStart = Date.now();
+
+    // All members argue in parallel within each round
+    const positions = await Promise.all(
+      assignments.map(async (assignment): Promise<DialecticPosition> => {
+        const systemPrompt = buildDialecticPrompt(
+          assignment,
+          round,
+          completedRounds,
+          input.camps,
+        );
+
+        const pos = await callCouncilMember(
+          assignment.member,
+          systemPrompt,
+          input.question,
+          input.globalConfig,
+        );
+
+        return {
+          ...pos,
+          role: assignment.role,
+          campName: assignment.camp?.name,
+          roundNumber: round,
+        };
+      }),
+    );
+
+    completedRounds.push({
+      roundNumber: round,
+      positions,
+      durationMs: Date.now() - roundStart,
+    });
+  }
+
+  return {
+    question: input.question,
+    camps: input.camps,
+    rounds: completedRounds,
+    totalDurationMs: Date.now() - totalStart,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Format dialectic results for steward consumption
+// ---------------------------------------------------------------------------
+
+export function formatDialecticResultsForSteward(result: DialecticResult): string {
+  const lines: string[] = [
+    `## Dialectic Deliberation`,
+    `**Question:** ${result.question}`,
+    `**Camps:** ${result.camps.map((c) => `${c.name} ("${c.position}")`).join(" vs. ")}`,
+    `**Rounds:** ${result.rounds.length} | **Total time:** ${(result.totalDurationMs / 1000).toFixed(1)}s`,
+    "",
+  ];
+
+  for (const round of result.rounds) {
+    lines.push(`### Round ${round.roundNumber} (${(round.durationMs / 1000).toFixed(1)}s)`);
+    lines.push("");
+
+    for (const pos of round.positions) {
+      const roleLabel = pos.role === "skeptic"
+        ? "SKEPTIC"
+        : `ADVOCATE: ${pos.campName}`;
+      const timing = pos.durationMs ? `${(pos.durationMs / 1000).toFixed(1)}s` : "n/a";
+      const tokens =
+        pos.inputTokens || pos.outputTokens
+          ? ` | ${pos.inputTokens ?? "?"}→${pos.outputTokens ?? "?"} tokens`
+          : "";
+
+      lines.push(`#### ${pos.modelName} [${roleLabel}]`);
+      lines.push(`*${timing}${tokens}*`);
+      lines.push("");
+
+      if (pos.error) {
+        lines.push(`**Error:** ${pos.error}`);
+      } else {
+        lines.push(pos.text);
+      }
+
+      lines.push("");
+    }
+
+    lines.push("---");
+    lines.push("");
+  }
+
+  lines.push(
+    "**You are the chair.** You just oversaw a multi-round dialectic. Synthesize:",
+    "",
+    "**Evolution:** How did positions change across rounds? What was conceded? What hardened?",
+    "",
+    "**Strongest surviving argument from each camp:** After multiple rounds of pressure, what still stands?",
+    "",
+    "**Exposed weaknesses:** Where did a position fail to hold up even with its own advocate refining it?",
+    "",
+    "**Emerged insights:** What surfaced that wasn't in the original framing?",
+    "",
+    "**Your judgment:** Given the strongest battle-tested versions of all arguments, what do you recommend — and why?",
+    "",
+    "Do not split the difference. Take a position.",
+  );
+
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8,8 +8,11 @@ import { extractConfigValue } from "./lib/config";
 
 import {
   conveneCouncil,
+  conveneDialectic,
   formatCouncilResultsForSteward,
+  formatDialecticResultsForSteward,
   resolveCouncilMembers,
+  clampRounds,
 } from "./lib/council";
 import { parseModelPool } from "./lib/project";
 import { getHivePaths, listProjects, resolveHiveHome } from "./lib/paths";
@@ -60,14 +63,22 @@ server.registerTool("convene_council", {
   description:
     "Send a question to multiple AI models in parallel and collect their independent positions. " +
     "Use for architecture decisions, tradeoff analysis, risk assessment, or any question where " +
-    "multiple perspectives add value. You act as chair — synthesize the results.",
+    "multiple perspectives add value. You act as chair — synthesize the results. " +
+    "Mode 'dialectic' assigns models to argue specific camps across multiple rounds.",
   inputSchema: {
     question: z.string().describe("The question to ask all council members. Be specific and give enough context."),
     models: z.array(z.string()).optional().describe("Model pool names to consult (e.g. ['opus', 'sonnet', 'gpt54']). Defaults to all configured models."),
     context: z.string().optional().describe("Additional context to include in the prompt to each model."),
-    persona: z.enum(["default", "analyst"]).optional().describe("Council member persona. 'analyst' adds structured analytical framing."),
+    persona: z.enum(["default", "analyst"]).optional().describe("Council member persona for standard mode. 'analyst' adds structured analytical framing."),
+    mode: z.enum(["standard", "analyst", "dialectic"]).optional().describe("Council mode. 'standard' for independent analysis, 'analyst' for structured analysis, 'dialectic' for adversarial multi-round debate."),
+    camps: z.array(z.object({
+      name: z.string().describe("Short name for this camp (e.g. 'rewrite', 'refactor')."),
+      position: z.string().describe("The position this camp argues for."),
+      brief: z.string().optional().describe("Optional additional context for this camp's advocate."),
+    })).optional().describe("Required for dialectic mode. The positions to argue. Each model is assigned a camp."),
+    rounds: z.number().optional().describe("Number of dialectic rounds (default 3, min 1, max 5). Models see each other's arguments between rounds."),
   },
-}, async ({ question, models: modelNames, context, persona }) => {
+}, async ({ question, models: modelNames, context, persona, mode, camps, rounds }) => {
   const paths = getHivePaths();
   const globalConfig = await Bun.file(paths.config).text().catch(() => "");
   const pool = parseModelPool(globalConfig);
@@ -86,7 +97,36 @@ server.registerTool("convene_council", {
   }
 
   const fullQuestion = context ? `${context}\n\n${question}` : question;
-  const resolvedPersona = persona === "analyst" ? "analyst" : null;
+
+  // Dialectic mode
+  if (mode === "dialectic") {
+    if (!camps || camps.length < 2) {
+      return {
+        content: [{ type: "text" as const, text: "Dialectic mode requires at least 2 camps." }],
+        isError: true,
+      };
+    }
+
+    const result = await conveneDialectic({
+      question: fullQuestion,
+      camps,
+      members,
+      globalConfig,
+      rounds: clampRounds(rounds),
+    });
+
+    let output = formatDialecticResultsForSteward(result);
+    const allPositions = result.rounds.flatMap((r) => r.positions);
+    const failed = allPositions.filter((p) => p.error);
+    if (failed.length > 0) {
+      output += `\n\n**Failed members:** ${failed.map((p) => `${p.modelName} (round ${p.roundNumber}): ${p.error}`).join("; ")}`;
+    }
+
+    return { content: [{ type: "text" as const, text: output }] };
+  }
+
+  // Standard or analyst mode
+  const resolvedPersona = (mode === "analyst" || persona === "analyst") ? "analyst" : null;
   const result = await conveneCouncil({ question: fullQuestion, members, globalConfig, persona: resolvedPersona });
 
   let output = formatCouncilResultsForSteward(result);


### PR DESCRIPTION
## Summary

Implements the first build of the cognitive accumulation layer: a dialectic council mode that enables multi-round adversarial debate between models. Unlike the standard council (parallel independent analysis), the dialectic assigns models to argue specific positions across multiple rounds, with each model seeing and responding to others' arguments.

## Key Changes

- **New dialectic types** in `src/lib/council.ts`:
  - `Camp`: Position definition with name, position statement, and optional brief
  - `DialecticAssignment`: Maps council members to advocate/skeptic roles
  - `DialecticPosition` & `DialecticRound`: Track positions and rounds
  - `DialecticResult`: Complete dialectic outcome with all rounds

- **Camp assignment logic** (`assignCamps`):
  - Round-robin assignment of members to camps
  - First extra member becomes skeptic (pressure-tests all positions)
  - Further extras cycle back to camps as additional advocates

- **Dialectic prompt generation** (`buildDialecticPrompt`):
  - Round 1: Independent advocacy for assigned position
  - Rounds 2+: Refined arguments with visibility into previous round positions
  - Final round: Strongest case incorporating all learned arguments
  - Skeptic prompts: Identify counterarguments, weak assumptions, underweighted failure modes

- **Main execution** (`conveneDialectic`):
  - Sequential rounds with parallel execution within each round
  - Configurable rounds (1-5, default 3)
  - Returns complete round history with timing

- **Results formatting** (`formatDialecticResultsForSteward`):
  - Structured output showing evolution across rounds
  - Per-round positions with role and camp labels
  - Chair synthesis prompt template for final judgment

- **CLI integration** (`src/commands/council.ts`):
  - `--mode dialectic` flag to enable dialectic mode
  - `--camps` flag for JSON array of camp definitions
  - `--rounds` flag to configure number of rounds (1-5)

- **MCP server integration** (`src/mcp-server.ts`):
  - Extended `convene_council` tool with dialectic mode support
  - New parameters: `mode`, `camps`, `rounds`

- **Comprehensive test coverage** (`src/__tests__/council.test.ts`):
  - Tests for `clampRounds`, `assignCamps`, `buildDialecticPrompt`, `formatDialecticResultsForSteward`
  - Edge cases: equal members/camps, extra members, skeptic behavior, round progression

## Implementation Details

The dialectic is genuinely sequential between rounds but parallel within rounds. Each model receives formatted summaries of all other models' previous arguments, enabling genuine debate rather than parallel one-shots. System prompts evolve across rounds, encouraging refinement and concession rather than repetition.

The skeptic role is distinct from advocates: it doesn't argue for a position but pressure-tests all positions, identifying unconsidered counterarguments and weak assumptions.

https://claude.ai/code/session_018hxPDVnMpGaSJU5riMujAg