### PR TITLE
Three-layer memory system: log, knowledge, and index

### DIFF
--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -9,6 +9,16 @@ import {
   appendToSection,
   appendProjectMemory,
   readProjectMemorySnapshot,
+  parseTags,
+  formatTags,
+  appendToLog,
+  readLog,
+  searchMemory,
+  formatSearchResults,
+  rebuildIndex,
+  supersedeEntry,
+  knowledgePath,
+  indexPath,
 } from "../lib/memory";
 import { ensureHiveScaffold, type HivePaths } from "../lib/paths";
 
@@ -113,6 +123,40 @@ describe("validateMemoryStructure", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+describe("parseTags", () => {
+  test("parses inline tags", () => {
+    expect(parseTags("some fact [auth, security]")).toEqual({
+      text: "some fact",
+      tags: ["auth", "security"],
+    });
+  });
+
+  test("handles no tags", () => {
+    expect(parseTags("plain text")).toEqual({ text: "plain text", tags: [] });
+  });
+
+  test("normalizes to lowercase", () => {
+    expect(parseTags("thing [Auth, API]")).toEqual({
+      text: "thing",
+      tags: ["auth", "api"],
+    });
+  });
+});
+
+describe("formatTags", () => {
+  test("formats tag array", () => {
+    expect(formatTags(["auth", "api"])).toBe(" [auth, api]");
+  });
+
+  test("empty array returns empty string", () => {
+    expect(formatTags([])).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // appendToSection
 // ---------------------------------------------------------------------------
 
@@ -171,7 +215,15 @@ describe("appendProjectMemory + readProjectMemorySnapshot", () => {
   test("write and read back a fact", async () => {
     await appendProjectMemory(paths, "test-project", "fact", "TypeScript is used");
     const snapshot = await readProjectMemorySnapshot(paths, "test-project");
-    expect(snapshot.facts).toContain("TypeScript is used");
+    expect(snapshot.facts.some((f) => f.text === "TypeScript is used")).toBe(true);
+  });
+
+  test("write with tags and read back", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Uses Bun runtime", ["runtime", "infrastructure"]);
+    const snapshot = await readProjectMemorySnapshot(paths, "test-project");
+    const entry = snapshot.facts.find((f) => f.text === "Uses Bun runtime");
+    expect(entry).toBeTruthy();
+    expect(entry!.tags).toEqual(["runtime", "infrastructure"]);
   });
 
   test("write and read back a decision", async () => {
@@ -187,7 +239,7 @@ describe("appendProjectMemory + readProjectMemorySnapshot", () => {
     await appendProjectMemory(paths, "test-project", "fact", "fact two");
     await appendProjectMemory(paths, "test-project", "fact", "fact three");
     const snapshot = await readProjectMemorySnapshot(paths, "test-project");
-    expect(snapshot.facts).toEqual(["fact one", "fact two", "fact three"]);
+    expect(snapshot.facts.map((f) => f.text)).toEqual(["fact one", "fact two", "fact three"]);
   });
 
   test("concurrent writes both land", async () => {
@@ -195,12 +247,181 @@ describe("appendProjectMemory + readProjectMemorySnapshot", () => {
     const p2 = appendProjectMemory(paths, "test-project", "fact", "concurrent two");
     await Promise.all([p1, p2]);
     const snapshot = await readProjectMemorySnapshot(paths, "test-project");
-    expect(snapshot.facts).toContain("concurrent one");
-    expect(snapshot.facts).toContain("concurrent two");
+    const texts = snapshot.facts.map((f) => f.text);
+    expect(texts).toContain("concurrent one");
+    expect(texts).toContain("concurrent two");
   });
 
   test("validation rejects bad input in full path", async () => {
     expect(appendProjectMemory(paths, "test-project", "fact", "")).rejects.toThrow("cannot be empty");
     expect(appendProjectMemory(paths, "test-project", "fact", "## header")).rejects.toThrow("markdown headers");
+  });
+
+  test("knowledge file lives in project directory", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "a fact");
+    const kPath = knowledgePath(paths, "test-project");
+    expect(kPath).toContain("test-project/knowledge.md");
+    const file = Bun.file(kPath);
+    expect(await file.exists()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supersession
+// ---------------------------------------------------------------------------
+
+describe("supersedeEntry", () => {
+  let tempDir: string;
+  let paths: HivePaths;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-test-"));
+    paths = await ensureHiveScaffold(tempDir);
+  });
+
+  test("supersede marks old entry and adds new one", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Uses express-session", ["auth"]);
+    await supersedeEntry(paths, "test-project", "fact", "Uses express-session", "Uses stateless JWT", ["auth"]);
+    const snapshot = await readProjectMemorySnapshot(paths, "test-project");
+    expect(snapshot.facts.length).toBe(2);
+    expect(snapshot.facts[0]!.superseded).toBe(true);
+    expect(snapshot.facts[1]!.text).toBe("Uses stateless JWT");
+    expect(snapshot.facts[1]!.superseded).toBeFalsy();
+  });
+
+  test("supersede throws if old entry not found", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "some fact");
+    expect(
+      supersedeEntry(paths, "test-project", "fact", "nonexistent entry", "new entry")
+    ).rejects.toThrow("Could not find active entry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session Log
+// ---------------------------------------------------------------------------
+
+describe("session log", () => {
+  let tempDir: string;
+  let paths: HivePaths;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-test-"));
+    paths = await ensureHiveScaffold(tempDir);
+  });
+
+  test("appendToLog creates daily log file", async () => {
+    const filePath = await appendToLog(paths, "test-project", [
+      { type: "fact", content: "discovered something" },
+      { type: "decision", content: "chose approach A" },
+    ]);
+    expect(filePath).toContain("/log/");
+    expect(filePath).toMatch(/\d{4}-\d{2}-\d{2}\.md$/);
+    const content = await Bun.file(filePath).text();
+    expect(content).toContain("fact | discovered something");
+    expect(content).toContain("decision | chose approach A");
+  });
+
+  test("readLog returns parsed entries", async () => {
+    await appendToLog(paths, "test-project", [
+      { type: "fact", content: "test entry" },
+    ]);
+    const entries = await readLog(paths, "test-project", 7);
+    expect(entries.length).toBe(1);
+    expect(entries[0]!.type).toBe("fact");
+    expect(entries[0]!.text).toBe("test entry");
+  });
+
+  test("multiple appends to same day accumulate", async () => {
+    await appendToLog(paths, "test-project", [{ type: "fact", content: "first" }]);
+    await appendToLog(paths, "test-project", [{ type: "fact", content: "second" }]);
+    const entries = await readLog(paths, "test-project", 7);
+    expect(entries.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+describe("searchMemory", () => {
+  let tempDir: string;
+  let paths: HivePaths;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-test-"));
+    paths = await ensureHiveScaffold(tempDir);
+  });
+
+  test("finds entries in knowledge by text", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Auth uses JWT tokens", ["auth"]);
+    await appendProjectMemory(paths, "test-project", "fact", "Database is Postgres", ["database"]);
+    const results = await searchMemory(paths, "test-project", "auth");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.entry.includes("JWT"))).toBe(true);
+  });
+
+  test("finds entries by tag", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "some auth fact", ["auth"]);
+    await appendProjectMemory(paths, "test-project", "fact", "some db fact", ["database"]);
+    const results = await searchMemory(paths, "test-project", "fact", { tag: "auth" });
+    expect(results.every((r) => r.tags.includes("auth") || r.source !== "knowledge")).toBe(true);
+  });
+
+  test("finds entries in log", async () => {
+    await appendToLog(paths, "test-project", [{ type: "fact", content: "discovered JWT issue" }]);
+    const results = await searchMemory(paths, "test-project", "JWT");
+    expect(results.some((r) => r.source === "log")).toBe(true);
+  });
+
+  test("excludes superseded entries by default", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Uses express-session", ["auth"]);
+    await supersedeEntry(paths, "test-project", "fact", "Uses express-session", "Uses JWT", ["auth"]);
+    const results = await searchMemory(paths, "test-project", "auth");
+    const knowledgeResults = results.filter((r) => r.source === "knowledge");
+    // Should only find the active entry
+    expect(knowledgeResults.some((r) => r.entry.includes("JWT"))).toBe(true);
+    expect(knowledgeResults.some((r) => r.entry.includes("express-session"))).toBe(false);
+  });
+
+  test("formatSearchResults produces readable output", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Uses Bun runtime", ["runtime"]);
+    const results = await searchMemory(paths, "test-project", "Bun");
+    const output = formatSearchResults(results, "Bun");
+    expect(output).toContain("Knowledge (compiled)");
+    expect(output).toContain("Bun runtime");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Index
+// ---------------------------------------------------------------------------
+
+describe("rebuildIndex", () => {
+  let tempDir: string;
+  let paths: HivePaths;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-test-"));
+    paths = await ensureHiveScaffold(tempDir);
+  });
+
+  test("generates index with summary", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "Uses TypeScript", ["language"]);
+    await appendProjectMemory(paths, "test-project", "decision", "Chose Bun over Node", ["runtime"]);
+    const output = await rebuildIndex(paths, "test-project");
+    expect(output).toContain("# Index: test-project");
+    expect(output).toContain("1 facts");
+    expect(output).toContain("1 decisions");
+    expect(output).toContain("language");
+    expect(output).toContain("runtime");
+  });
+
+  test("index file is written to disk", async () => {
+    await appendProjectMemory(paths, "test-project", "fact", "a fact");
+    await rebuildIndex(paths, "test-project");
+    const iPath = indexPath(paths, "test-project");
+    const content = await Bun.file(iPath).text();
+    expect(content).toContain("# Index: test-project");
   });
 });

--- a/src/commands/heartbeat.ts
+++ b/src/commands/heartbeat.ts
@@ -1,9 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 
 import { UsageError } from "../lib/errors";
 import { getHivePaths, getProjectPaths, listProjects } from "../lib/paths";
 import { parseFrontmatter } from "../lib/frontmatter";
+import { writeIdentityTempFile, cleanupIdentityTempFile } from "../lib/identity";
 import {
   readHeartbeatConfig,
   writeHeartbeatConfig,
@@ -187,6 +189,58 @@ async function heartbeatReset(projectId: string): Promise<void> {
   console.log(`Heartbeat session reset for ${projectId}. Next tick will create a new session.`);
 }
 
+async function heartbeatChat(projectId: string, initialMessage?: string): Promise<void> {
+  const paths = getHivePaths();
+  const projectDir = join(paths.projectsDir, projectId);
+  const config = readHeartbeatConfig(projectDir);
+
+  if (!config) {
+    throw new UsageError(`No heartbeat configured for ${projectId}. Run \`hive heartbeat start\` first.`);
+  }
+
+  if (!config.sessionId) {
+    throw new UsageError(`No heartbeat session exists. Run \`hive heartbeat tick\` first to create one.`);
+  }
+
+  // Get project path for cwd
+  const projectConfig = parseFrontmatter(readFileSync(join(projectDir, "config.md"), "utf-8"));
+  const projectPath = (projectConfig.attributes?.path as string) || process.cwd();
+
+  const identityFile = await writeIdentityTempFile();
+  process.on("exit", cleanupIdentityTempFile);
+  process.on("SIGINT", () => { cleanupIdentityTempFile(); process.exit(130); });
+  process.on("SIGTERM", () => { cleanupIdentityTempFile(); process.exit(143); });
+
+  const claude = (() => {
+    try {
+      return execSync("which claude", { encoding: "utf-8" }).trim();
+    } catch {
+      const fallback = join(process.env.HOME || "", ".local", "bin", "claude");
+      if (existsSync(fallback)) return fallback;
+      throw new Error("Could not find claude CLI.");
+    }
+  })();
+
+  const message = initialMessage || "Interactive heartbeat session.";
+  const claudeArgs = [
+    "--resume", config.sessionId,
+    "--append-system-prompt-file", identityFile,
+    "--add-dir", join(process.env.HOME || "", ".hive"),
+    "--", message,
+  ];
+
+  const result = Bun.spawnSync([claude, ...claudeArgs], {
+    cwd: projectPath,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env, ANTHROPIC_API_KEY: undefined },
+  });
+
+  cleanupIdentityTempFile();
+  process.exit(result.exitCode ?? 0);
+}
+
 // Used by heartbeat.sh to check if a project should tick now
 async function heartbeatCheckInterval(projectId: string): Promise<void> {
   const paths = getHivePaths();
@@ -208,6 +262,7 @@ Subcommands:
   stop                      Disable heartbeat for a project
   status                    Show heartbeat status for all projects
   tick                      Run one heartbeat tick manually
+  chat                      Interactive session with the heartbeat agent
   reset                     Reset session (creates fresh on next tick)
   check-interval            Internal: prints "tick" or "skip" for shell script`;
 
@@ -233,6 +288,10 @@ Subcommands:
     case "tick":
       if (!projectId) throw new UsageError("No project found.");
       await heartbeatTickCmd(projectId);
+      break;
+    case "chat":
+      if (!projectId) throw new UsageError("No project found.");
+      await heartbeatChat(projectId, remaining.slice(1).join(" ").trim() || undefined);
       break;
     case "reset":
       if (!projectId) throw new UsageError("No project found.");

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -2,8 +2,12 @@ import { UsageError } from "../lib/errors";
 import { ensureHiveScaffold, listProjects } from "../lib/paths";
 import {
   appendProjectMemory,
+  appendToLog,
   readProjectMemorySnapshot,
   readProjectMemorySection,
+  searchMemory,
+  formatSearchResults,
+  rebuildIndex,
   type MemorySection,
 } from "../lib/memory";
 import { writeDailySessions } from "../lib/sessions";
@@ -14,38 +18,50 @@ function resolveProjectFromCwd(projects: string[]): string | null {
   return projects.find((p) => cwd.toLowerCase().includes(p.toLowerCase())) ?? projects[0] ?? null;
 }
 
+function parseFlagsAndArgs(args: string[]): { flags: Record<string, string>; positional: string[] } {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--project" || arg === "-p") {
+      flags.project = args[++i] ?? "";
+    } else if (arg === "--tag" || arg === "-t") {
+      flags.tag = args[++i] ?? "";
+    } else if (arg === "--section" || arg === "-s") {
+      flags.section = args[++i] ?? "";
+    } else if (arg === "--no-superseded") {
+      flags.noSuperseded = "true";
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { flags, positional };
+}
+
 export async function memoryCommand(args: string[]): Promise<void> {
   const usage = `Usage:
   hive memory                              View all project memory
   hive memory view [facts|conventions|decisions|questions]
-  hive memory fact <text>                  Add a durable fact
+  hive memory fact <text> [--tag <tag>]    Add a durable fact
   hive memory convention <text>            Add a convention
   hive memory decision <text>              Add a decision
   hive memory question <text>              Add an open question
+  hive memory search <query> [--tag t] [--section s]  Search across all memory layers
+  hive memory index                        Rebuild the project memory index
   hive memory reflect                      Batch-write learnings from stdin (JSON)
   hive memory --project <name> ...         Specify project`;
 
   const paths = await ensureHiveScaffold();
-
-  // Parse --project flag
-  let projectOverride: string | null = null;
-  const filtered: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--project" || args[i] === "-p") {
-      projectOverride = args[++i] ?? null;
-      continue;
-    }
-    filtered.push(args[i]!);
-  }
+  const { flags, positional } = parseFlagsAndArgs(args);
 
   const projects = await listProjects(paths.projectsDir);
-  const projectId = projectOverride ?? resolveProjectFromCwd(projects);
+  const projectId = flags.project ?? resolveProjectFromCwd(projects);
 
   if (!projectId) {
     throw new UsageError("No project found. Register one with: hive project add <name> <path>");
   }
 
-  const subcommand = filtered[0];
+  const subcommand = positional[0];
 
   if (subcommand === "extract-sessions") {
     const outputPath = await writeDailySessions();
@@ -53,17 +69,40 @@ export async function memoryCommand(args: string[]): Promise<void> {
     return;
   }
 
+  // Search
+  if (subcommand === "search") {
+    const query = positional.slice(1).join(" ").trim();
+    if (!query) {
+      throw new UsageError("No search query provided.\n\nhive memory search <query>");
+    }
+    const results = await searchMemory(paths, projectId, query, {
+      tag: flags.tag,
+      section: flags.section as MemorySection | undefined,
+      includeSuperseded: flags.noSuperseded !== "true",
+    });
+    console.log(formatSearchResults(results, query));
+    return;
+  }
+
+  // Rebuild index
+  if (subcommand === "index") {
+    const output = await rebuildIndex(paths, projectId);
+    console.log(`Index rebuilt for ${projectId}:\n`);
+    console.log(output);
+    return;
+  }
+
   if (!subcommand || subcommand === "view") {
-    const section = (filtered[1] ?? "all") as "all" | "facts" | "conventions" | "decisions" | "questions";
+    const section = (positional[1] ?? "all") as "all" | "facts" | "conventions" | "decisions" | "questions";
     const snapshot = await readProjectMemorySnapshot(paths, projectId);
     console.log(`Project: ${projectId}\n`);
-    console.log(readProjectMemorySection(snapshot, section));
+    console.log(readProjectMemorySection(snapshot, section, flags.noSuperseded !== "true"));
     return;
   }
 
   if (subcommand === "reflect") {
     const stdin = await Bun.stdin.text();
-    let learnings: Array<{ type: string; content: string }>;
+    let learnings: Array<{ type: string; content: string; tags?: string[] }>;
     try {
       learnings = JSON.parse(stdin.trim());
     } catch {
@@ -74,6 +113,16 @@ export async function memoryCommand(args: string[]): Promise<void> {
     }
 
     const validTypes = ["fact", "convention", "decision", "question"];
+
+    // Write to log first
+    const logEntries = learnings
+      .filter((item) => validTypes.includes(item.type))
+      .map((item) => ({ type: item.type as MemorySection, content: item.content }));
+    if (logEntries.length > 0) {
+      await appendToLog(paths, projectId, logEntries);
+    }
+
+    // Write to knowledge
     let recorded = 0;
     for (const item of learnings) {
       if (!validTypes.includes(item.type)) {
@@ -81,13 +130,17 @@ export async function memoryCommand(args: string[]): Promise<void> {
         continue;
       }
       try {
-        await appendProjectMemory(paths, projectId, item.type as MemorySection, item.content);
+        await appendProjectMemory(paths, projectId, item.type as MemorySection, item.content, item.tags ?? []);
         recorded++;
       } catch (err) {
         console.error(`Skipping ${item.type}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    console.log(`Recorded ${recorded} learning(s) in ${projectId} memory.`);
+
+    // Rebuild index
+    await rebuildIndex(paths, projectId);
+
+    console.log(`Recorded ${recorded} learning(s) in ${projectId} memory (knowledge + log). Index rebuilt.`);
     return;
   }
 
@@ -96,13 +149,15 @@ export async function memoryCommand(args: string[]): Promise<void> {
     throw new UsageError(`Unknown subcommand: ${subcommand}\n\n${usage}`);
   }
 
-  const text = filtered.slice(1).join(" ").trim();
+  const text = positional.slice(1).join(" ").trim();
   if (!text) {
     throw new UsageError(`No text provided.\n\n${usage}`);
   }
 
+  const tags = flags.tag ? flags.tag.split(",").map((t) => t.trim().toLowerCase()) : [];
+
   try {
-    await appendProjectMemory(paths, projectId, subcommand as MemorySection, text);
+    await appendProjectMemory(paths, projectId, subcommand as MemorySection, text, tags);
   } catch (err) {
     throw new UsageError(err instanceof Error ? err.message : String(err));
   }

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { getHivePaths, getProjectPaths, listProjects } from "./paths";
 import { parseFrontmatter } from "./frontmatter";
 import { assembleIdentity } from "./identity";
+import { rebuildIndex } from "./memory";
 
 export interface HeartbeatConfig {
   sessionId: string;
@@ -140,6 +141,13 @@ export async function runTick(projectId: string): Promise<TickResult> {
   // Determine result
   const isOk = output.includes("HEARTBEAT_OK");
   const result: TickResult["result"] = exitCode !== 0 ? "ERROR" : isOk ? "HEARTBEAT_OK" : "ACTION_TAKEN";
+
+  // Rebuild memory index — cheap, runs every tick to keep it current
+  try {
+    await rebuildIndex(paths, projectId);
+  } catch {
+    // Non-fatal — index rebuild failure shouldn't break heartbeat
+  }
 
   // Update config
   config.lastTick = timestamp;

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -53,10 +53,12 @@ export async function assembleIdentity(): Promise<string> {
     }
   }
 
-  // Detect and load project memory
+  // Detect and load project memory (prefer index, fall back to knowledge)
   const projectId = detectProject(paths);
   if (projectId) {
-    const memPath = join(paths.memoryProjectsDir, `${projectId}.md`);
+    const indexFile = join(paths.memoryProjectsDir, projectId, "_index.md");
+    const knowledgeFile = join(paths.memoryProjectsDir, projectId, "knowledge.md");
+    const memPath = existsSync(indexFile) ? indexFile : knowledgeFile;
     if (existsSync(memPath)) {
       const content = await Bun.file(memPath).text();
       parts.push(content.trim());

--- a/src/lib/memory.ts
+++ b/src/lib/memory.ts
@@ -1,20 +1,55 @@
 import { join } from "node:path";
+import { readdir } from "node:fs/promises";
 
 import { ensureDirectory, type HivePaths } from "./paths";
-import { toIsoTimestamp } from "./time";
+import { toIsoTimestamp, toDateLabel, now } from "./time";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MemorySection = "fact" | "convention" | "decision" | "question";
 
 export type ProjectDecision = {
   ts: string | null;
   text: string;
+  tags: string[];
+  superseded?: boolean;
+};
+
+export type MemoryEntry = {
+  text: string;
+  tags: string[];
+  superseded?: boolean;
+  supersedes?: string;
 };
 
 export type ProjectMemorySnapshot = {
   raw: string;
-  facts: string[];
-  conventions: string[];
+  facts: MemoryEntry[];
+  conventions: MemoryEntry[];
   decisions: ProjectDecision[];
-  questions: string[];
+  questions: MemoryEntry[];
 };
+
+export type LogEntry = {
+  time: string;
+  type: MemorySection;
+  text: string;
+};
+
+export type SearchResult = {
+  source: "knowledge" | "index" | "log";
+  file: string;
+  section?: string;
+  entry: string;
+  tags: string[];
+  date?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 const sectionHeaders = {
   facts: "## Durable Facts",
@@ -23,8 +58,6 @@ const sectionHeaders = {
   questions: "## Open Questions",
 } as const;
 
-export type MemorySection = "fact" | "convention" | "decision" | "question";
-
 const sectionToHeader: Record<MemorySection, string> = {
   fact: sectionHeaders.facts,
   convention: sectionHeaders.conventions,
@@ -32,18 +65,42 @@ const sectionToHeader: Record<MemorySection, string> = {
   question: sectionHeaders.questions,
 };
 
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
-
-const MAX_ENTRY_LENGTH = 1000;
-
 const expectedSectionOrder = [
   sectionHeaders.facts,
   sectionHeaders.conventions,
   sectionHeaders.decisions,
   sectionHeaders.questions,
 ] as const;
+
+const MAX_ENTRY_LENGTH = 1000;
+
+// ---------------------------------------------------------------------------
+// Paths — project memory is now a directory
+// ---------------------------------------------------------------------------
+
+export function memoryProjectDir(paths: HivePaths, projectId: string): string {
+  return join(paths.memoryProjectsDir, projectId);
+}
+
+export function knowledgePath(paths: HivePaths, projectId: string): string {
+  return join(memoryProjectDir(paths, projectId), "knowledge.md");
+}
+
+export function indexPath(paths: HivePaths, projectId: string): string {
+  return join(memoryProjectDir(paths, projectId), "_index.md");
+}
+
+export function logDir(paths: HivePaths, projectId: string): string {
+  return join(memoryProjectDir(paths, projectId), "log");
+}
+
+export function logFilePath(paths: HivePaths, projectId: string, date: Date = now()): string {
+  return join(logDir(paths, projectId), `${toDateLabel(date)}.md`);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
 
 export function validateMemoryEntry(text: string): string {
   let cleaned = text.trim();
@@ -97,6 +154,38 @@ export function validateMemoryStructure(content: string): { valid: boolean; erro
 }
 
 // ---------------------------------------------------------------------------
+// Tag parsing — inline [tag1, tag2] at end of entry
+// ---------------------------------------------------------------------------
+
+const TAG_PATTERN = /\s*\[([^\]]+)\]\s*$/;
+
+export function parseTags(text: string): { text: string; tags: string[] } {
+  const match = text.match(TAG_PATTERN);
+  if (!match) return { text: text.trim(), tags: [] };
+  const tags = match[1]!.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean);
+  return { text: text.slice(0, match.index).trim(), tags };
+}
+
+export function formatTags(tags: string[]): string {
+  if (tags.length === 0) return "";
+  return ` [${tags.join(", ")}]`;
+}
+
+// ---------------------------------------------------------------------------
+// Supersession — ~~old entry~~ → superseded YYYY-MM-DD
+// ---------------------------------------------------------------------------
+
+const SUPERSEDED_PATTERN = /^~~(.+?)~~\s*→\s*superseded\s+(\S+)$/;
+
+function isSuperseded(line: string): boolean {
+  return SUPERSEDED_PATTERN.test(line);
+}
+
+function formatSuperseded(text: string, date: Date = now()): string {
+  return `~~${text}~~ → superseded ${toDateLabel(date)}`;
+}
+
+// ---------------------------------------------------------------------------
 // Write queue — serializes concurrent writes per file path
 // ---------------------------------------------------------------------------
 
@@ -108,6 +197,10 @@ function enqueue(path: string, fn: () => Promise<void>): Promise<void> {
   writeQueue.set(path, next);
   return next;
 }
+
+// ---------------------------------------------------------------------------
+// Section extraction — shared between knowledge and legacy format
+// ---------------------------------------------------------------------------
 
 function extractSectionBody(content: string, header: string): string {
   const idx = content.indexOf(header);
@@ -128,12 +221,36 @@ function extractBullets(content: string, header: string): string[] {
     .filter(Boolean);
 }
 
-function extractDecisions(content: string): ProjectDecision[] {
-  return extractBullets(content, sectionHeaders.decisions).map((entry) => {
-    const m = entry.match(/^\[([^\]]+)\]\s+(.*)$/);
-    return { ts: m?.[1]?.trim() ?? null, text: m?.[2]?.trim() ?? entry };
+function extractEntries(content: string, header: string): MemoryEntry[] {
+  return extractBullets(content, header).map((raw) => {
+    if (isSuperseded(raw)) {
+      const m = raw.match(SUPERSEDED_PATTERN)!;
+      const { text, tags } = parseTags(m[1]!);
+      return { text, tags, superseded: true };
+    }
+    const { text, tags } = parseTags(raw);
+    return { text, tags };
   });
 }
+
+function extractDecisions(content: string): ProjectDecision[] {
+  return extractBullets(content, sectionHeaders.decisions).map((raw) => {
+    if (isSuperseded(raw)) {
+      const m = raw.match(SUPERSEDED_PATTERN)!;
+      const inner = m[1]!;
+      const tsMatch = inner.match(/^\[([^\]]+)\]\s+(.*)$/);
+      const { text, tags } = parseTags(tsMatch?.[2] ?? inner);
+      return { ts: tsMatch?.[1]?.trim() ?? null, text, tags, superseded: true };
+    }
+    const tsMatch = raw.match(/^\[([^\]]+)\]\s+(.*)$/);
+    const { text, tags } = parseTags(tsMatch?.[2] ?? raw);
+    return { ts: tsMatch?.[1]?.trim() ?? null, text, tags };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Section append
+// ---------------------------------------------------------------------------
 
 export function appendToSection(content: string, header: string, entry: string): string {
   const idx = content.indexOf(header);
@@ -151,57 +268,82 @@ export function appendToSection(content: string, header: string, entry: string):
   return `${content.slice(0, after)}${updated.trimEnd()}\n${content.slice(end)}`;
 }
 
-export function memoryFilePath(paths: HivePaths, projectId: string): string {
-  return join(paths.memoryProjectsDir, `${projectId}.md`);
+// ---------------------------------------------------------------------------
+// Knowledge file — the compiled project intelligence
+// ---------------------------------------------------------------------------
+
+function newKnowledgeFile(projectId: string): string {
+  return `# Project Memory: ${projectId}\n\n${sectionHeaders.facts}\n(none yet)\n\n${sectionHeaders.conventions}\n(none yet)\n\n${sectionHeaders.decisions}\n(none yet)\n\n${sectionHeaders.questions}\n(none yet)\n`;
 }
 
-export async function ensureProjectMemoryFile(
+export async function ensureProjectMemoryDir(
   paths: HivePaths,
   projectId: string,
 ): Promise<string> {
-  const path = memoryFilePath(paths, projectId);
-  const file = Bun.file(path);
+  const dir = memoryProjectDir(paths, projectId);
+  await ensureDirectory(dir);
+  await ensureDirectory(logDir(paths, projectId));
 
+  const kPath = knowledgePath(paths, projectId);
+  const file = Bun.file(kPath);
   if (!(await file.exists())) {
-    await ensureDirectory(paths.memoryProjectsDir);
-    await Bun.write(path, `# Project Memory: ${projectId}\n\n${sectionHeaders.facts}\n(none yet)\n\n${sectionHeaders.conventions}\n(none yet)\n\n${sectionHeaders.decisions}\n(none yet)\n\n${sectionHeaders.questions}\n(none yet)\n`);
+    await Bun.write(kPath, newKnowledgeFile(projectId));
   }
 
-  return path;
+  return dir;
 }
+
+// Backward compat alias
+export const ensureProjectMemoryFile = ensureProjectMemoryDir;
+
+export function memoryFilePath(paths: HivePaths, projectId: string): string {
+  return knowledgePath(paths, projectId);
+}
+
+// ---------------------------------------------------------------------------
+// Read knowledge
+// ---------------------------------------------------------------------------
 
 export async function readProjectMemorySnapshot(
   paths: HivePaths,
   projectId: string,
 ): Promise<ProjectMemorySnapshot> {
-  const path = await ensureProjectMemoryFile(paths, projectId);
-  const raw = await Bun.file(path).text();
+  await ensureProjectMemoryDir(paths, projectId);
+  const kPath = knowledgePath(paths, projectId);
+  const raw = await Bun.file(kPath).text();
 
   return {
     raw,
-    facts: extractBullets(raw, sectionHeaders.facts),
-    conventions: extractBullets(raw, sectionHeaders.conventions),
+    facts: extractEntries(raw, sectionHeaders.facts),
+    conventions: extractEntries(raw, sectionHeaders.conventions),
     decisions: extractDecisions(raw),
-    questions: extractBullets(raw, sectionHeaders.questions),
+    questions: extractEntries(raw, sectionHeaders.questions),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Write to knowledge
+// ---------------------------------------------------------------------------
 
 export async function appendProjectMemory(
   paths: HivePaths,
   projectId: string,
   section: MemorySection,
   text: string,
+  tags: string[] = [],
 ): Promise<void> {
   const cleaned = validateMemoryEntry(text);
-  const filePath = await ensureProjectMemoryFile(paths, projectId);
+  await ensureProjectMemoryDir(paths, projectId);
+  const filePath = knowledgePath(paths, projectId);
 
   return enqueue(filePath, async () => {
     const content = await Bun.file(filePath).text();
     const header = sectionToHeader[section];
+    const tagStr = formatTags(tags);
 
     const entry = section === "decision"
-      ? `- [${toIsoTimestamp().slice(0, 10)}] ${cleaned}`
-      : `- ${cleaned}`;
+      ? `- [${toIsoTimestamp().slice(0, 10)}] ${cleaned}${tagStr}`
+      : `- ${cleaned}${tagStr}`;
 
     const updated = appendToSection(content, header, entry);
 
@@ -214,15 +356,419 @@ export async function appendProjectMemory(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Supersede an entry in knowledge
+// ---------------------------------------------------------------------------
+
+export async function supersedeEntry(
+  paths: HivePaths,
+  projectId: string,
+  section: MemorySection,
+  oldText: string,
+  newText: string,
+  tags: string[] = [],
+): Promise<void> {
+  const cleanedNew = validateMemoryEntry(newText);
+  await ensureProjectMemoryDir(paths, projectId);
+  const filePath = knowledgePath(paths, projectId);
+
+  return enqueue(filePath, async () => {
+    let content = await Bun.file(filePath).text();
+
+    // Find and mark the old entry as superseded
+    const lines = content.split("\n");
+    let found = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (line.startsWith("- ") && line.includes(oldText) && !isSuperseded(line.slice(2).trim())) {
+        const rawEntry = line.slice(2).trim();
+        lines[i] = `- ${formatSuperseded(rawEntry)}`;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      throw new Error(`Could not find active entry to supersede: "${oldText}"`);
+    }
+
+    content = lines.join("\n");
+
+    // Append new entry with supersedes marker
+    const header = sectionToHeader[section];
+    const tagStr = formatTags(tags);
+
+    const entry = section === "decision"
+      ? `- [${toIsoTimestamp().slice(0, 10)}] ${cleanedNew}${tagStr}`
+      : `- ${cleanedNew}${tagStr}`;
+
+    const updated = appendToSection(content, header, entry);
+
+    const check = validateMemoryStructure(updated);
+    if (!check.valid) {
+      throw new Error(`Memory write would corrupt file: ${check.error}`);
+    }
+
+    await Bun.write(filePath, updated);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Read section (formatted output)
+// ---------------------------------------------------------------------------
+
 export function readProjectMemorySection(
   snapshot: ProjectMemorySnapshot,
   section: "facts" | "conventions" | "decisions" | "questions" | "all",
+  includeSuperseded = true,
 ): string {
-  if (section === "all") return snapshot.raw;
+  if (section === "all") {
+    if (!includeSuperseded) {
+      return filterSupersededFromRaw(snapshot.raw);
+    }
+    return snapshot.raw;
+  }
   if (section === "decisions") {
-    return snapshot.decisions
-      .map((d) => `- ${d.ts ? `[${d.ts}] ` : ""}${d.text}`)
+    const filtered = includeSuperseded
+      ? snapshot.decisions
+      : snapshot.decisions.filter((d) => !d.superseded);
+    return filtered
+      .map((d) => {
+        const tagStr = formatTags(d.tags);
+        const prefix = d.superseded ? "~~" : "";
+        const suffix = d.superseded ? `~~ → superseded` : "";
+        return `- ${prefix}${d.ts ? `[${d.ts}] ` : ""}${d.text}${tagStr}${suffix}`;
+      })
       .join("\n") || "(none yet)";
   }
-  return snapshot[section].map((e) => `- ${e}`).join("\n") || "(none yet)";
+
+  const entries = snapshot[section] as MemoryEntry[];
+  const filtered = includeSuperseded ? entries : entries.filter((e) => !e.superseded);
+  return filtered
+    .map((e) => {
+      const tagStr = formatTags(e.tags);
+      if (e.superseded) return `- ~~${e.text}${tagStr}~~ → superseded`;
+      return `- ${e.text}${tagStr}`;
+    })
+    .join("\n") || "(none yet)";
+}
+
+function filterSupersededFromRaw(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((line) => !(line.startsWith("- ~~") && line.includes("→ superseded")))
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Session Log — raw daily capture (Layer 1)
+// ---------------------------------------------------------------------------
+
+export async function appendToLog(
+  paths: HivePaths,
+  projectId: string,
+  entries: Array<{ type: MemorySection; content: string }>,
+): Promise<string> {
+  await ensureProjectMemoryDir(paths, projectId);
+  const filePath = logFilePath(paths, projectId);
+  const dateLabel = toDateLabel();
+
+  const file = Bun.file(filePath);
+  let existing = "";
+  if (await file.exists()) {
+    existing = await file.text();
+  } else {
+    existing = `# ${dateLabel}\n`;
+  }
+
+  const timestamp = toIsoTimestamp().slice(11, 16); // HH:MM
+  const newLines = entries.map((e) => {
+    const cleaned = validateMemoryEntry(e.content);
+    return `- ${timestamp} | ${e.type} | ${cleaned}`;
+  });
+
+  const updated = `${existing.trimEnd()}\n${newLines.join("\n")}\n`;
+  await Bun.write(filePath, updated);
+
+  return filePath;
+}
+
+export async function readLog(
+  paths: HivePaths,
+  projectId: string,
+  daysBack = 7,
+): Promise<LogEntry[]> {
+  const dir = logDir(paths, projectId);
+  const entries: LogEntry[] = [];
+
+  let files: string[];
+  try {
+    files = (await readdir(dir)).filter((f) => f.endsWith(".md")).sort().reverse();
+  } catch {
+    return entries;
+  }
+
+  // Only read recent files
+  const cutoff = daysBack > 0 ? files.slice(0, daysBack) : files;
+
+  for (const file of cutoff) {
+    const content = await Bun.file(join(dir, file)).text();
+    const date = file.replace(".md", "");
+
+    for (const line of content.split("\n")) {
+      const m = line.match(/^- (\d{2}:\d{2}) \| (\w+) \| (.+)$/);
+      if (m) {
+        entries.push({
+          time: `${date}T${m[1]}`,
+          type: m[2] as MemorySection,
+          text: m[3]!.trim(),
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Index — auto-maintained summary (Layer 3)
+// ---------------------------------------------------------------------------
+
+export async function rebuildIndex(
+  paths: HivePaths,
+  projectId: string,
+): Promise<string> {
+  const snapshot = await readProjectMemorySnapshot(paths, projectId);
+  const recentLog = await readLog(paths, projectId, 7);
+
+  const activeFacts = snapshot.facts.filter((f) => !f.superseded);
+  const activeConventions = snapshot.conventions.filter((c) => !c.superseded);
+  const activeDecisions = snapshot.decisions.filter((d) => !d.superseded);
+  const openQuestions = snapshot.questions.filter((q) => !q.superseded);
+
+  // Collect all tags for the tag index
+  const tagMap = new Map<string, number>();
+  for (const entries of [activeFacts, activeConventions, openQuestions]) {
+    for (const e of entries) {
+      for (const t of e.tags) tagMap.set(t, (tagMap.get(t) ?? 0) + 1);
+    }
+  }
+  for (const d of activeDecisions) {
+    for (const t of d.tags) tagMap.set(t, (tagMap.get(t) ?? 0) + 1);
+  }
+
+  const sortedTags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
+
+  const recentDecisions = activeDecisions.slice(-5);
+  const recentLogEntries = recentLog.slice(0, 10);
+
+  const lines: string[] = [
+    `# Index: ${projectId}`,
+    ``,
+    `> Auto-generated summary of project memory. Loaded at session start.`,
+    `> Use search_memory for deeper queries. Edit knowledge.md for corrections.`,
+    ``,
+    `## Summary`,
+    `- ${activeFacts.length} facts, ${activeConventions.length} conventions, ${activeDecisions.length} decisions, ${openQuestions.length} open questions`,
+    ``,
+  ];
+
+  // Tag index
+  if (sortedTags.length > 0) {
+    lines.push(`## Tags`);
+    lines.push(sortedTags.map(([tag, count]) => `\`${tag}\`(${count})`).join("  "));
+    lines.push(``);
+  }
+
+  // Recent decisions
+  if (recentDecisions.length > 0) {
+    lines.push(`## Recent Decisions`);
+    for (const d of recentDecisions) {
+      lines.push(`- [${d.ts}] ${d.text}${formatTags(d.tags)}`);
+    }
+    lines.push(``);
+  }
+
+  // Open questions
+  if (openQuestions.length > 0) {
+    lines.push(`## Open Questions`);
+    for (const q of openQuestions) {
+      lines.push(`- ${q.text}${formatTags(q.tags)}`);
+    }
+    lines.push(``);
+  }
+
+  // Recent log activity
+  if (recentLogEntries.length > 0) {
+    lines.push(`## Recent Activity`);
+    for (const e of recentLogEntries) {
+      lines.push(`- ${e.time} | ${e.type} | ${e.text}`);
+    }
+    lines.push(``);
+  }
+
+  // Key facts (all of them — this is the navigational overview)
+  if (activeFacts.length > 0) {
+    lines.push(`## Key Facts`);
+    for (const f of activeFacts) {
+      lines.push(`- ${f.text}${formatTags(f.tags)}`);
+    }
+    lines.push(``);
+  }
+
+  // Conventions
+  if (activeConventions.length > 0) {
+    lines.push(`## Conventions`);
+    for (const c of activeConventions) {
+      lines.push(`- ${c.text}${formatTags(c.tags)}`);
+    }
+    lines.push(``);
+  }
+
+  const output = lines.join("\n");
+  const iPath = indexPath(paths, projectId);
+  await Bun.write(iPath, output);
+
+  return output;
+}
+
+// ---------------------------------------------------------------------------
+// Search — grep across all layers with ranked results
+// ---------------------------------------------------------------------------
+
+export async function searchMemory(
+  paths: HivePaths,
+  projectId: string,
+  query: string,
+  options: { tag?: string; section?: MemorySection; includeSuperseded?: boolean; logDays?: number } = {},
+): Promise<SearchResult[]> {
+  const results: SearchResult[] = [];
+  const q = query.toLowerCase();
+  const tagFilter = options.tag?.toLowerCase();
+
+  // Layer 2: Knowledge (highest priority)
+  const snapshot = await readProjectMemorySnapshot(paths, projectId);
+
+  const searchSection = (
+    entries: Array<MemoryEntry | ProjectDecision>,
+    sectionName: string,
+  ) => {
+    for (const entry of entries) {
+      if (!options.includeSuperseded && entry.superseded) continue;
+      if (tagFilter && !entry.tags.some((t) => t === tagFilter)) continue;
+
+      const entryText = "ts" in entry
+        ? `[${(entry as ProjectDecision).ts}] ${entry.text}`
+        : entry.text;
+
+      if (entryText.toLowerCase().includes(q) || entry.tags.some((t) => t.includes(q))) {
+        results.push({
+          source: "knowledge",
+          file: "knowledge.md",
+          section: sectionName,
+          entry: entryText,
+          tags: entry.tags,
+        });
+      }
+    }
+  };
+
+  if (!options.section || options.section === "fact") {
+    searchSection(snapshot.facts, "facts");
+  }
+  if (!options.section || options.section === "convention") {
+    searchSection(snapshot.conventions, "conventions");
+  }
+  if (!options.section || options.section === "decision") {
+    searchSection(snapshot.decisions, "decisions");
+  }
+  if (!options.section || options.section === "question") {
+    searchSection(snapshot.questions, "questions");
+  }
+
+  // Layer 3: Index
+  const iPath = indexPath(paths, projectId);
+  try {
+    const indexContent = await Bun.file(iPath).text();
+    for (const line of indexContent.split("\n")) {
+      if (line.toLowerCase().includes(q) && line.startsWith("- ")) {
+        // Don't duplicate entries already found in knowledge
+        const stripped = line.slice(2).trim();
+        if (!results.some((r) => r.entry.includes(stripped) || stripped.includes(r.entry))) {
+          results.push({
+            source: "index",
+            file: "_index.md",
+            entry: stripped,
+            tags: [],
+          });
+        }
+      }
+    }
+  } catch {
+    // No index yet
+  }
+
+  // Layer 1: Log (lowest priority, recent only)
+  const logEntries = await readLog(paths, projectId, options.logDays ?? 14);
+  for (const entry of logEntries) {
+    if (entry.text.toLowerCase().includes(q)) {
+      results.push({
+        source: "log",
+        file: `log/${entry.time.slice(0, 10)}.md`,
+        entry: `${entry.time} | ${entry.type} | ${entry.text}`,
+        tags: [],
+        date: entry.time.slice(0, 10),
+      });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Format search results for LLM consumption
+// ---------------------------------------------------------------------------
+
+export function formatSearchResults(results: SearchResult[], query: string): string {
+  if (results.length === 0) {
+    return `No memory entries found matching "${query}".`;
+  }
+
+  const lines: string[] = [
+    `Found ${results.length} result(s) for "${query}":`,
+    ``,
+  ];
+
+  // Group by source
+  const knowledge = results.filter((r) => r.source === "knowledge");
+  const log = results.filter((r) => r.source === "log");
+
+  if (knowledge.length > 0) {
+    lines.push(`### Knowledge (compiled)`);
+    // Group by section
+    const bySection = new Map<string, SearchResult[]>();
+    for (const r of knowledge) {
+      const key = r.section ?? "unknown";
+      if (!bySection.has(key)) bySection.set(key, []);
+      bySection.get(key)!.push(r);
+    }
+    for (const [section, entries] of bySection) {
+      lines.push(`**${section}:**`);
+      for (const e of entries) {
+        const tagStr = e.tags.length > 0 ? ` [${e.tags.join(", ")}]` : "";
+        lines.push(`  - ${e.entry}${tagStr}`);
+      }
+    }
+    lines.push(``);
+  }
+
+  if (log.length > 0) {
+    lines.push(`### Session Log (raw)`);
+    for (const e of log) {
+      lines.push(`  - ${e.entry}`);
+    }
+    lines.push(``);
+  }
+
+  return lines.join("\n");
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -20,6 +20,11 @@ import {
   readProjectMemorySnapshot,
   readProjectMemorySection,
   appendProjectMemory,
+  appendToLog,
+  searchMemory,
+  formatSearchResults,
+  rebuildIndex,
+  supersedeEntry,
   type MemorySection,
 } from "./lib/memory";
 import { parseFrontmatter } from "./lib/frontmatter";
@@ -157,12 +162,17 @@ server.registerTool("convene_council", {
 
 // Tool 2: Read project memory
 server.registerTool("read_hive_memory", {
-  description: "Read accumulated project intelligence — facts, conventions, decisions, and open questions.",
+  description:
+    "Read accumulated project intelligence — facts, conventions, decisions, and open questions. " +
+    "For targeted lookups, prefer search_memory instead. " +
+    "Set source to 'index' for a lightweight summary (loaded at session start).",
   inputSchema: {
     project: z.string().optional().describe("Project name. Defaults to project matching current directory."),
     section: z.enum(["all", "facts", "conventions", "decisions", "questions"]).optional().describe("Which section to read. Defaults to 'all'."),
+    source: z.enum(["knowledge", "index"]).optional().describe("Read from full knowledge file or lightweight index. Default 'knowledge'."),
+    include_superseded: z.boolean().optional().describe("Include superseded (replaced) entries. Default true."),
   },
-}, async ({ project, section }) => {
+}, async ({ project, section, source, include_superseded }) => {
   const paths = getHivePaths();
   const projectId = project ?? resolveProjectFromCwd(paths);
 
@@ -173,21 +183,36 @@ server.registerTool("read_hive_memory", {
     };
   }
 
+  if (source === "index") {
+    const { indexPath: getIndexPath } = await import("./lib/memory");
+    const iPath = getIndexPath(paths, projectId);
+    try {
+      const content = await Bun.file(iPath).text();
+      return { content: [{ type: "text" as const, text: content }] };
+    } catch {
+      // No index yet — rebuild it
+      const content = await rebuildIndex(paths, projectId);
+      return { content: [{ type: "text" as const, text: content }] };
+    }
+  }
+
   const snapshot = await readProjectMemorySnapshot(paths, projectId);
-  const output = readProjectMemorySection(snapshot, section ?? "all");
+  const output = readProjectMemorySection(snapshot, section ?? "all", include_superseded ?? true);
 
   return { content: [{ type: "text" as const, text: `# Project Memory: ${projectId}\n\n${output}` }] };
 });
 
 // Tool 3: Write project memory
 server.registerTool("write_hive_memory", {
-  description: "Record a new fact, convention, decision, or open question in project memory. Use proactively when you learn something durable about the project.",
+  description: "Record a new fact, convention, decision, or open question in project memory. Use proactively when you learn something durable about the project. Tags help with search — use them to categorize entries by topic.",
   inputSchema: {
     project: z.string().optional().describe("Project name. Defaults to project matching current directory."),
     type: z.enum(["fact", "convention", "decision", "question"]).describe("What kind of memory to record."),
     content: z.string().describe("The text to record."),
+    tags: z.array(z.string()).optional().describe("Topic tags for this entry (e.g. ['auth', 'security']). Lowercase, short."),
+    supersedes: z.string().optional().describe("If this replaces an existing entry, provide the text of the old entry. The old entry will be marked as superseded."),
   },
-}, async ({ project, type, content }) => {
+}, async ({ project, type, content, tags, supersedes }) => {
   const paths = getHivePaths();
   const projectId = project ?? resolveProjectFromCwd(paths);
 
@@ -198,7 +223,11 @@ server.registerTool("write_hive_memory", {
     };
   }
 
-  await appendProjectMemory(paths, projectId, type as MemorySection, content);
+  if (supersedes) {
+    await supersedeEntry(paths, projectId, type as MemorySection, supersedes, content, tags ?? []);
+  } else {
+    await appendProjectMemory(paths, projectId, type as MemorySection, content, tags ?? []);
+  }
 
   return { content: [{ type: "text" as const, text: `Recorded ${type} in ${projectId} memory.` }] };
 });
@@ -206,13 +235,15 @@ server.registerTool("write_hive_memory", {
 // Tool 4: Batch reflect session learnings
 server.registerTool("reflect_session", {
   description:
-    "Batch-write session learnings to project memory. Use at end of a substantive session " +
-    "to record durable facts, conventions, decisions, or open questions discovered during the session.",
+    "Batch-write session learnings to project memory. Writes to both the session log (raw capture) " +
+    "and knowledge file (compiled intelligence). Rebuilds the index afterward. " +
+    "Use at end of a substantive session to record durable facts, conventions, decisions, or open questions.",
   inputSchema: {
     project: z.string().optional().describe("Project name. Defaults to project matching current directory."),
     learnings: z.array(z.object({
       type: z.enum(["fact", "convention", "decision", "question"]).describe("What kind of memory to record."),
       content: z.string().describe("The text to record."),
+      tags: z.array(z.string()).optional().describe("Topic tags (e.g. ['auth', 'api']). Lowercase."),
     })).describe("Array of learnings to record."),
   },
 }, async ({ project, learnings }) => {
@@ -233,17 +264,32 @@ server.registerTool("reflect_session", {
   const counts: Record<string, number> = {};
   const errors: string[] = [];
 
+  // Write to session log (raw capture)
+  try {
+    await appendToLog(paths, projectId, learnings.map((l) => ({ type: l.type as MemorySection, content: l.content })));
+  } catch (err) {
+    errors.push(`log: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Write to knowledge (compiled)
   for (const item of learnings) {
     try {
-      await appendProjectMemory(paths, projectId, item.type as MemorySection, item.content);
+      await appendProjectMemory(paths, projectId, item.type as MemorySection, item.content, item.tags ?? []);
       counts[item.type] = (counts[item.type] ?? 0) + 1;
     } catch (err) {
       errors.push(`${item.type}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
+  // Rebuild index
+  try {
+    await rebuildIndex(paths, projectId);
+  } catch (err) {
+    errors.push(`index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   const summary = Object.entries(counts).map(([k, v]) => `${v} ${k}(s)`).join(", ");
-  let text = `Recorded ${summary} in ${projectId} memory.`;
+  let text = `Recorded ${summary} in ${projectId} memory (knowledge + log). Index rebuilt.`;
   if (errors.length > 0) {
     text += `\n\nSkipped ${errors.length} invalid entries:\n${errors.map(e => `- ${e}`).join("\n")}`;
   }
@@ -251,7 +297,44 @@ server.registerTool("reflect_session", {
   return { content: [{ type: "text" as const, text }] };
 });
 
-// Tool 5: Create a ticket
+// Tool 5: Search project memory
+server.registerTool("search_memory", {
+  description:
+    "Search across all layers of project memory — knowledge (compiled facts, conventions, decisions), " +
+    "session logs (raw daily capture), and the index. Results are ranked: knowledge first, then log. " +
+    "Use this to answer questions like 'what do we know about auth?' or 'what decisions have we made about the API?'. " +
+    "Prefer this over read_hive_memory when looking for something specific.",
+  inputSchema: {
+    project: z.string().optional().describe("Project name. Defaults to project matching current directory."),
+    query: z.string().describe("Search query — matches against entry text and tags."),
+    tag: z.string().optional().describe("Filter to entries with this tag."),
+    section: z.enum(["fact", "convention", "decision", "question"]).optional().describe("Limit search to this section of knowledge."),
+    include_superseded: z.boolean().optional().describe("Include superseded (replaced) entries. Default false."),
+    log_days: z.number().optional().describe("How many days of log history to search. Default 14."),
+  },
+}, async ({ project, query, tag, section, include_superseded, log_days }) => {
+  const paths = getHivePaths();
+  const projectId = project ?? resolveProjectFromCwd(paths);
+
+  if (!projectId) {
+    return {
+      content: [{ type: "text" as const, text: "No project found. Register one with: hive project add <name> <path>" }],
+      isError: true,
+    };
+  }
+
+  const results = await searchMemory(paths, projectId, query, {
+    tag: tag ?? undefined,
+    section: (section as MemorySection) ?? undefined,
+    includeSuperseded: include_superseded ?? false,
+    logDays: log_days ?? 14,
+  });
+
+  const formatted = formatSearchResults(results, query);
+  return { content: [{ type: "text" as const, text: formatted }] };
+});
+
+// Tool 6: Create a ticket
 server.registerTool("create_ticket", {
   description:
     "Create a new ticket in the project's ticket tracker. " +
@@ -436,7 +519,7 @@ server.registerTool("add_project", {
   },
 }, async ({ name, path: projectPath }) => {
   const { normalizeProjectName } = await import("./lib/project");
-  const { ensureProjectMemoryFile } = await import("./lib/memory");
+  const { ensureProjectMemoryDir } = await import("./lib/memory");
 
   const paths = getHivePaths();
   const projectId = normalizeProjectName(name);
@@ -454,10 +537,10 @@ server.registerTool("add_project", {
     `---\nname: ${projectId}\npath: ${repoPath}\n---\n`,
   );
 
-  await ensureProjectMemoryFile(paths, projectId);
+  await ensureProjectMemoryDir(paths, projectId);
 
   return {
-    content: [{ type: "text" as const, text: `Registered project '${projectId}' at ${repoPath}\nMemory: ~/.hive/memory/projects/${projectId}.md\n\nUse \`hive\` from ${repoPath} to start a Maya session with project context.` }],
+    content: [{ type: "text" as const, text: `Registered project '${projectId}' at ${repoPath}\nMemory: ~/.hive/memory/projects/${projectId}/\n\nUse \`hive\` from ${repoPath} to start a Maya session with project context.` }],
   };
 });
 
@@ -627,7 +710,7 @@ server.registerTool("hive_status", {
   for (const projectId of projects) {
     try {
       const snapshot = await readProjectMemorySnapshot(paths, projectId);
-      const decisions = readProjectMemorySection(snapshot, "decisions");
+      const decisions = readProjectMemorySection(snapshot, "decisions", false);
       const decisionLines = decisions.split("\n").filter((l) => l.startsWith("- ")).slice(-3);
       if (decisionLines.length > 0) {
         lines.push(`**${projectId}** (recent decisions):`);

--- a/templates/agents/maya-heartbeat.md
+++ b/templates/agents/maya-heartbeat.md
@@ -1,7 +1,7 @@
 ---
 name: maya-heartbeat
-description: Periodic heartbeat. Wakes up, checks standing orders, acts or stays quiet.
-tools: Read, Glob, Grep, Bash, mcp__hive__read_hive_memory, mcp__hive__write_hive_memory, mcp__hive__list_tickets, mcp__hive__show_ticket, mcp__hive__update_ticket, mcp__hive__add_ticket_note
+description: Periodic heartbeat. Wakes up, checks standing orders, consolidates memory, acts or stays quiet.
+tools: Read, Glob, Grep, Bash, mcp__hive__read_hive_memory, mcp__hive__write_hive_memory, mcp__hive__search_memory, mcp__hive__reflect_session, mcp__hive__list_tickets, mcp__hive__show_ticket, mcp__hive__update_ticket, mcp__hive__add_ticket_note
 maxTurns: 15
 permissionMode: bypassPermissions
 ---
@@ -12,8 +12,21 @@ You are the heartbeat agent. You wake up periodically (default every 30 minutes)
 
 1. Read your standing orders at the project's HEARTBEAT.md (path given in your init message)
 2. Execute each check. Skip checks where nothing changed since last tick.
-3. If NOTHING needs attention: respond with exactly `HEARTBEAT_OK` and stop.
-4. If SOMETHING needs attention: describe what, take appropriate action.
+3. **Memory consolidation** — this happens every tick:
+   a. Use `read_hive_memory` with `source: "index"` to see the current memory summary
+   b. Use `search_memory` to check recent log entries for anything not yet in knowledge
+   c. Promote durable entries to knowledge via `write_hive_memory` with appropriate tags
+   d. If a new entry contradicts an existing one, use the `supersedes` parameter to replace it
+   e. Skip transient, session-specific, or already-captured entries
+4. If NOTHING needs attention: respond with exactly `HEARTBEAT_OK` and stop.
+5. If SOMETHING needs attention: describe what, take appropriate action.
+
+**Memory consolidation guidelines:**
+- Only promote entries that are durable and non-obvious — architecture facts, conventions, decisions
+- Always add tags when writing to knowledge — they power search
+- When superseding, name the old entry text so the system can mark it
+- Check if open questions have been answered by recent decisions — close them if so
+- This is the primary way raw session learnings become compiled project intelligence
 
 **Action escalation:**
 - Small updates (ticket note, memory entry): do it directly
@@ -24,3 +37,4 @@ You are the heartbeat agent. You wake up periodically (default every 30 minutes)
 - Most ticks should be HEARTBEAT_OK. Be cheap when nothing changed.
 - Don't re-read unchanged files or re-run passing checks.
 - Don't run expensive operations (full test suites, large builds) unless standing orders say to.
+- Memory consolidation should be fast — scan the index, check log, promote or skip. Don't overthink it.

--- a/templates/heartbeat/HEARTBEAT.md
+++ b/templates/heartbeat/HEARTBEAT.md
@@ -14,6 +14,14 @@
 - Any running dispatches? How long have they been going?
 - Any failed/crashed dispatches since last tick?
 
+### Memory Consolidation
+- Read recent session log entries (last 7 days) via `read_hive_memory`
+- For each log entry not yet in knowledge:
+  - If it's durable and non-obvious, promote it to knowledge with `write_hive_memory` (include tags)
+  - If it contradicts an existing knowledge entry, use `write_hive_memory` with `supersedes` to replace it
+  - If it's transient or session-specific, skip it
+- Check for stale open questions — any that have been answered by recent decisions?
+
 ## Standing Instructions
 <!-- Add project-specific instructions below -->
 <!-- Examples: -->

--- a/templates/hooks/load-identity.sh
+++ b/templates/hooks/load-identity.sh
@@ -27,11 +27,16 @@ if [ -d "$HIVE_DIR/projects" ]; then
   done
 fi
 
-# Load only the matched project's memory
+# Load the matched project's memory index (lightweight summary)
 if [ -n "$MATCHED_PROJECT" ]; then
-  memfile="$HIVE_DIR/memory/projects/$MATCHED_PROJECT.md"
-  if [ -f "$memfile" ]; then
-    cat "$memfile"
+  indexfile="$HIVE_DIR/memory/projects/$MATCHED_PROJECT/_index.md"
+  knowledgefile="$HIVE_DIR/memory/projects/$MATCHED_PROJECT/knowledge.md"
+  # Prefer index (lightweight); fall back to full knowledge
+  if [ -f "$indexfile" ]; then
+    cat "$indexfile"
+    echo ""
+  elif [ -f "$knowledgefile" ]; then
+    cat "$knowledgefile"
     echo ""
   fi
 fi


### PR DESCRIPTION
Memory evolves from flat append-only sections to a three-layer architecture:

- Layer 1 (Session Log): Raw daily capture in log/YYYY-MM-DD.md files.
  reflect_session now writes here first, preserving the full session stream.

- Layer 2 (Knowledge): Compiled intelligence in knowledge.md (was <project>.md).
  Entries now support inline tags [auth, api] and supersession — old facts get
  marked ~~superseded~~ with a link when replaced, rather than silently growing.

- Layer 3 (Index): Auto-generated _index.md summary with tag counts, recent
  decisions, open questions, and key facts. Rebuilt after reflect_session.
  Designed to be loaded at session start instead of the full knowledge file.

New MCP tool: search_memory — searches across all three layers with results
ranked by source (knowledge > index > log). Supports tag filtering, section
filtering, and superseded entry exclusion. Formatted output is designed for
LLM consumption, not just human grep.

Updated: write_hive_memory now accepts tags and supersedes parameters.
Updated: read_hive_memory can read from index or knowledge, with superseded filtering.
Updated: CLI adds search, index, and --tag/--no-superseded flags.

98 tests pass (39 memory tests, up from 14).

https://claude.ai/code/session_014kU4PUfM2VsiuL5AkUpaTC