### PR TITLE
Add /goal self-loop mode to dispatch with configurable turn cap

### DIFF
--- a/src/__tests__/dispatch.test.ts
+++ b/src/__tests__/dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 
-import { buildRunWrapper } from "../commands/dispatch";
+import { buildExecutorMessage, buildRunWrapper } from "../commands/dispatch";
 
 const baseOpts = {
   projectPath: "/Users/x/work/hive",
@@ -67,5 +67,47 @@ describe("buildRunWrapper", () => {
     expect(script).toContain('echo "complete" > "/Users/x/.hive/runs/RUN-099/status"');
     expect(script).toContain('echo "partial" > "/Users/x/.hive/runs/RUN-099/status"');
     expect(script).toContain('echo "blocked" > "/Users/x/.hive/runs/RUN-099/status"');
+  });
+});
+
+const baseMessageOpts = {
+  runDir: "/Users/x/.hive/runs/RUN-099",
+  projectId: "hive",
+  goalText: "Refactor the dispatch wrapper to use /goal",
+  maxTurns: 20,
+  useGoalCommand: true,
+};
+
+describe("buildExecutorMessage", () => {
+  test("wraps the message in /goal when enabled", () => {
+    const msg = buildExecutorMessage(baseMessageOpts);
+    expect(msg.startsWith("/goal ")).toBe(true);
+  });
+
+  test("references the plan file in the success condition", () => {
+    const msg = buildExecutorMessage(baseMessageOpts);
+    expect(msg).toContain("/Users/x/.hive/runs/RUN-099/plan.md");
+    expect(msg).toContain("marked [x]");
+    expect(msg).toContain("committed");
+  });
+
+  test("includes the turn cap in the /goal stop clause", () => {
+    expect(buildExecutorMessage(baseMessageOpts)).toContain("or stop after 20 turns");
+    expect(buildExecutorMessage({ ...baseMessageOpts, maxTurns: 5 })).toContain("or stop after 5 turns");
+  });
+
+  test("preserves run dir, project, and goal text in the body", () => {
+    const msg = buildExecutorMessage(baseMessageOpts);
+    expect(msg).toContain("Run directory: /Users/x/.hive/runs/RUN-099");
+    expect(msg).toContain("Plan file: /Users/x/.hive/runs/RUN-099/plan.md");
+    expect(msg).toContain("Project: hive");
+    expect(msg).toContain("Refactor the dispatch wrapper to use /goal");
+  });
+
+  test("omits the /goal prefix and stop clause when disabled", () => {
+    const msg = buildExecutorMessage({ ...baseMessageOpts, useGoalCommand: false });
+    expect(msg.startsWith("/goal")).toBe(false);
+    expect(msg).not.toContain("or stop after");
+    expect(msg).toContain("Goal:\nRefactor the dispatch wrapper to use /goal");
   });
 });

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -21,6 +21,40 @@ async function nextRunId(runsDir: string): Promise<string> {
 }
 
 
+export interface ExecutorMessageOpts {
+  runDir: string;
+  projectId: string;
+  goalText: string;
+  maxTurns: number;
+  useGoalCommand: boolean;
+}
+
+// Wraps the dispatched goal in Claude Code's `/goal` slash command so the
+// executor self-loops until the success condition holds, instead of
+// completing a single turn and exiting. The condition doubles as the first
+// turn's prompt: Claude reads it to know what to do, the Haiku evaluator
+// reads it after each turn to decide whether to keep going. Requires
+// Claude Code >= 2.1.139; older versions will treat the `/goal` text as a
+// literal prompt and the run still attempts the task once.
+export function buildExecutorMessage(opts: ExecutorMessageOpts): string {
+  const { runDir, projectId, goalText, maxTurns, useGoalCommand } = opts;
+
+  const body = `Run directory: ${runDir}
+Plan file: ${runDir}/plan.md
+Project: ${projectId}
+
+Goal:
+${goalText}`;
+
+  if (!useGoalCommand) {
+    return body;
+  }
+
+  return `/goal The dispatched task is complete when every checklist item in ${runDir}/plan.md is marked [x] and all implementation changes are committed in the worktree branch. If you hit a hard blocker, document it in the plan and stop. (or stop after ${maxTurns} turns)
+
+${body}`;
+}
+
 export interface RunWrapperOpts {
   projectPath: string;
   timeoutMin: number;
@@ -173,7 +207,20 @@ function findClaude(): string {
 export async function dispatchCommand(args: string[]): Promise<void> {
   const usage = `Usage: hive dispatch "<goal>" [--project <name>] [--ticket <id>]
        hive dispatch --ticket TK-007
-       hive dispatch --plan <path-to-plan.md>`;
+       hive dispatch --plan <path-to-plan.md>
+
+Options:
+  --project <name>     Project to dispatch against (defaults to cwd resolution)
+  --ticket <id>        Use ticket as the goal
+  --plan <path>        Append plan file to the goal
+  --timeout <min>      Hard wall-clock cap (default 30)
+  --model <id>         Executor model (default claude-opus-4-6)
+  --max-turns <n>      Inner /goal turn cap (default 20)
+
+Env:
+  HIVE_DISPATCH_MODEL       Override default model
+  HIVE_DISPATCH_MAX_TURNS   Override default turn cap
+  HIVE_DISPATCH_NO_GOAL=1   Disable /goal self-loop (one-shot mode)`;
 
   if (args.length === 0) throw new UsageError(usage);
 
@@ -189,6 +236,11 @@ export async function dispatchCommand(args: string[]): Promise<void> {
   // instruction-following and fewer-subagents bias hurt judgment-heavy
   // autonomous work. Override via --model or HIVE_DISPATCH_MODEL env.
   let model = process.env.HIVE_DISPATCH_MODEL || "claude-opus-4-6";
+  // Inner-loop turn cap for the `/goal` self-verifier. Belt to the wrapper's
+  // wall-clock timeout suspenders.
+  let maxTurns = parseInt(process.env.HIVE_DISPATCH_MAX_TURNS || "20", 10);
+  if (isNaN(maxTurns) || maxTurns < 1) maxTurns = 20;
+  const useGoalCommand = process.env.HIVE_DISPATCH_NO_GOAL !== "1";
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--project" && args[i + 1]) {
@@ -202,6 +254,9 @@ export async function dispatchCommand(args: string[]): Promise<void> {
       if (isNaN(timeoutMin) || timeoutMin < 1) timeoutMin = 30;
     } else if (args[i] === "--model" && args[i + 1]) {
       model = args[++i]!;
+    } else if (args[i] === "--max-turns" && args[i + 1]) {
+      const parsed = parseInt(args[++i]!, 10);
+      if (!isNaN(parsed) && parsed >= 1) maxTurns = parsed;
     } else if (!args[i]!.startsWith("--")) {
       goal = args[i]!;
     }
@@ -272,7 +327,13 @@ export async function dispatchCommand(args: string[]): Promise<void> {
   // the wrapper — embedding the message as a bash string literal causes `set -u`
   // to abort on any `${...}` token in the goal text (common in ticket bodies
   // with shell snippets). Command substitution from a file side-steps expansion.
-  const message = `Your run directory is: ${runDir}\nWrite your plan to: ${runDir}/plan.md\nProject: ${projectId}\n\nGoal:\n${goalText}`;
+  const message = buildExecutorMessage({
+    runDir,
+    projectId,
+    goalText,
+    maxTurns,
+    useGoalCommand,
+  });
   const messagePath = join(runDir, "message.txt");
   await Bun.write(messagePath, message);
 
@@ -309,6 +370,11 @@ export async function dispatchCommand(args: string[]): Promise<void> {
 
   console.log(`Dispatched ${runId} (${projectId})`);
   console.log(`  Goal: ${goalText.split("\n")[0]!.slice(0, 80)}`);
+  if (useGoalCommand) {
+    console.log(`  Mode: /goal self-loop, max ${maxTurns} turns, ${timeoutMin}m wall-clock`);
+  } else {
+    console.log(`  Mode: one-shot, ${timeoutMin}m wall-clock`);
+  }
   console.log(`  Log:  ${logPath}`);
   console.log(`  PID:  ${child.pid}`);
 }


### PR DESCRIPTION
## Summary

Adds support for Claude Code's `/goal` slash command to the dispatch system, enabling autonomous self-looping until a success condition is met, rather than completing a single turn and exiting. The executor now wraps the goal in a `/goal` block that references a plan file checklist and includes a configurable turn cap as a safety belt to the wrapper's wall-clock timeout.

## Key Changes

- **New `buildExecutorMessage()` function**: Constructs the executor message with optional `/goal` wrapping. When enabled, the message includes:
  - A success condition tied to plan file checklist completion (`[x]` markers) and committed changes
  - A turn cap clause (e.g., "or stop after 20 turns") to bound the self-loop
  - The original run directory, project ID, and goal text in the message body

- **Configuration options**:
  - `--max-turns <n>`: Set the inner `/goal` turn cap (default 20)
  - `HIVE_DISPATCH_MAX_TURNS` env var: Override default turn cap
  - `HIVE_DISPATCH_NO_GOAL=1` env var: Disable `/goal` mode for one-shot execution
  - Updated usage text documenting all options and environment variables

- **Dispatch flow updates**:
  - Parse `--max-turns` CLI argument and environment variables
  - Replace inline message construction with `buildExecutorMessage()` call
  - Log the execution mode (self-loop vs. one-shot) and turn cap to console output

- **Test coverage**: Added comprehensive tests for `buildExecutorMessage()` covering:
  - `/goal` wrapping behavior when enabled/disabled
  - Plan file reference and success condition formatting
  - Turn cap inclusion in the stop clause
  - Preservation of run directory, project, and goal text in message body

## Implementation Details

The `/goal` command requires Claude Code >= 2.1.139; older versions treat the `/goal` text as a literal prompt and the run still attempts the task once (graceful degradation).

The turn cap acts as a secondary safety mechanism: the wrapper's wall-clock timeout (`--timeout`) is the primary hard limit, while the `/goal` turn cap bounds the inner self-verification loop.

https://claude.ai/code/session_01Ntpge15ALpobjp3oAKadUF